### PR TITLE
fix: update references of docx_to_txt.py

### DIFF
--- a/sccs
+++ b/sccs
@@ -5,6 +5,6 @@ import subprocess
 command = sys.argv[1] if len(sys.argv) > 1 else None
 
 if command == "init":
-    subprocess.run(["python3", "docx_to_text.py"] + sys.argv[1:]) 
+    subprocess.run(["python3", "init.py"] + sys.argv[1:]) 
 
 # If on MacOS / Linux, move this file to /usr/local/bin and make it executable with `chmod +x sccs`

--- a/sccs.bat
+++ b/sccs.bat
@@ -6,7 +6,7 @@ import subprocess
 command = sys.argv[1] if len(sys.argv) > 1 else None
 
 if command == "init":
-    subprocess.run(["python3", "docx_to_text.py"] + sys.argv[1:]) 
+    subprocess.run(["python3", "init.py"] + sys.argv[1:]) 
 
 @REM # Instructions to set up sccs.bat in CLI on Windows
 


### PR DESCRIPTION
# Update references of docx_to_txt.py

In the previous PR, #4 renamed docx_to_txt.py to init.py. References were not updated, but this PR solves that.

