### PR TITLE
feat/Remove Roadmap section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ A lightweight distributed version control system designed to help legal professi
 - [Features](#-features)
 - [Installation](#-installation)
 - [Contributing](#-contributing)
-- [Roadmap](#%EF%B8%8F-roadmap)
 - [License](#-license)
 - [Contact](mailto:danielaphillion@gmail.com)
 
@@ -56,9 +55,6 @@ pip install -r requirements.txt
 
 ## 🤝 Contributing
 Please refer to [CONTRIBUTING.md](CONTRIBUTING.md) for info on how to get started contributing! It is greatly appreciated 😁 !
-
-## 🗺️ Roadmap
-The full roadmap is available in [ROADMAP.md](ROADMAP.md)
 
 ## 📃 License
 SCCS uses the GPLv3, which you can find in [LICENSE](LICENSE)

--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ A lightweight distributed version control system designed to help legal professi
 
 ## 🚧 Features to Make 
 
-- **See Roadmap for more details**
-
 - Host repository online like Git
 
 - Different Branches


### PR DESCRIPTION
# Remove ROADMAP.md link

Removed the Roadmap section from the README, because the page was not well maintained.