### PR TITLE
Feat/sccs diff

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -7,7 +7,7 @@ import docx2txt
 base_file = sys.argv[2] if len(sys.argv) > 2 else None
 commit_to_diff = sys.argv[3] if len(sys.argv) > 3 else None
 
-if base_file or commit_to_diff:
+if base_file and commit_to_diff:
     
     directory_path = Path(base_file).with_suffix('')
     if directory_path.name == directory_path.parent.name:

--- a/diff.py
+++ b/diff.py
@@ -42,7 +42,7 @@ if not commit_to_diff:
     print("No commit file path provided to compare.")
     sys.exit(1)
 
-elif not Path(commit_to_diff).suffix.lower() == ".txt" or not Path(commit_to_diff).is_file():
+elif Path(commit_to_diff).suffix.lower() != ".txt" or not Path(commit_to_diff).is_file():
     print("Invalid commit file path, make sure the file exists and is a .txt file")
     sys.exit(1)
 else:

--- a/diff.py
+++ b/diff.py
@@ -1,0 +1,49 @@
+import os
+from pathlib import Path
+import sys
+
+import docx2txt
+
+base_file = sys.argv[2] if len(sys.argv) > 2 else None
+commit_to_diff = sys.argv[3] if len(sys.argv) > 3 else None
+
+if base_file or commit_to_diff:
+    
+    directory_path = Path(base_file).with_suffix('')
+    if directory_path.name == directory_path.parent.name:
+        directory_path = directory_path.parent
+    
+    base_file = os.path.join(directory_path, os.path.basename(base_file))
+
+    if not Path(base_file).is_file():
+        print("Base file not found. Please provide a valid base file path.")
+        sys.exit(1)
+else:
+    print("Please provide both the base file path and the commit hash to compare.")
+    sys.exit(1)
+
+if not Path(os.path.join(directory_path, ".sccs")).is_dir():
+    print("This file has not been initialized with SCCS.")
+    print("Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+elif base_file and Path(base_file).suffix.lower() == ".docx" and Path(base_file).is_file():
+    try: 
+        base_text = docx2txt.process(base_file)
+    except Exception as e:
+        print(f"Error processing base .docx file: {e}")
+        sys.exit(1)
+
+else: 
+    print("Invalid base file path, make sure the file exists and is a .docx file")
+    sys.exit(1)
+
+if not commit_to_diff:
+    print("No commit hash provided to compare.")
+    sys.exit(1)
+
+elif not Path(commit_to_diff).suffix.lower() == ".txt" or not Path(commit_to_diff).is_file():
+    print("Invalid commit file path, make sure the file exists and is a .txt file")
+    sys.exit(1)
+
+

--- a/diff.py
+++ b/diff.py
@@ -57,18 +57,22 @@ else:
 def to_lines(text):
     return [line + "\n" for line in text.splitlines()]
 
-diff = list(
-    (unified_diff(
+diff = (
+    unified_diff(
         to_lines(base_text),
         to_lines(commit_text),
         fromfile=Path(base_file).name, 
         tofile=Path(commit_to_diff).name
     )
 )
-)
 
-if not diff:
+first_diff_line = next(diff, None)
+
+if first_diff_line is None:
     print("No differences found between the base file and the commit.")
+    print("Diff complete.")
+    sys.exit(0)
+
 else:
     print("".join(diff))
 

--- a/diff.py
+++ b/diff.py
@@ -19,7 +19,7 @@ if base_file or commit_to_diff:
         print("Base file not found. Please provide a valid base file path.")
         sys.exit(1)
 else:
-    print("Please provide both the base file path and the commit hash to compare.")
+    print("Please provide both the base file path and the commit file path to compare.")
     sys.exit(1)
 
 if not Path(os.path.join(directory_path, ".sccs")).is_dir():
@@ -39,7 +39,7 @@ else:
     sys.exit(1)
 
 if not commit_to_diff:
-    print("No commit hash provided to compare.")
+    print("No commit file path provided to compare.")
     sys.exit(1)
 
 elif not Path(commit_to_diff).suffix.lower() == ".txt" or not Path(commit_to_diff).is_file():

--- a/diff.py
+++ b/diff.py
@@ -57,7 +57,12 @@ else:
 def to_lines(text):
     return [line + "\n" for line in text.splitlines()]
 
-print("".join(unified_diff(to_lines(base_text), to_lines(commit_text), fromfile=Path(base_file).name, tofile=Path(commit_to_diff).name)))
+diff = (unified_diff(to_lines(base_text), to_lines(commit_text), fromfile=Path(base_file).name, tofile=Path(commit_to_diff).name))
+
+if not list(diff):
+    print("No differences found between the base file and the commit.")
+else:
+    print("".join(diff))
 
 print("Diff complete.")
 

--- a/diff.py
+++ b/diff.py
@@ -39,7 +39,7 @@ else:
     sys.exit(1)
 
 
-elif Path(commit_to_diff).suffix.lower() != ".txt" or not Path(commit_to_diff).is_file():
+if Path(commit_to_diff).suffix.lower() != ".txt" or not Path(commit_to_diff).is_file():
     print("Invalid commit file path, make sure the file exists and is a .txt file")
     sys.exit(1)
 else:

--- a/diff.py
+++ b/diff.py
@@ -38,9 +38,6 @@ else:
     print("Invalid base file path, make sure the file exists and is a .docx file")
     sys.exit(1)
 
-if not commit_to_diff:
-    print("No commit file path provided to compare.")
-    sys.exit(1)
 
 elif Path(commit_to_diff).suffix.lower() != ".txt" or not Path(commit_to_diff).is_file():
     print("Invalid commit file path, make sure the file exists and is a .txt file")

--- a/diff.py
+++ b/diff.py
@@ -57,9 +57,17 @@ else:
 def to_lines(text):
     return [line + "\n" for line in text.splitlines()]
 
-diff = (unified_diff(to_lines(base_text), to_lines(commit_text), fromfile=Path(base_file).name, tofile=Path(commit_to_diff).name))
+diff = list(
+    (unified_diff(
+        to_lines(base_text),
+        to_lines(commit_text),
+        fromfile=Path(base_file).name, 
+        tofile=Path(commit_to_diff).name
+    )
+)
+)
 
-if not list(diff):
+if not diff:
     print("No differences found between the base file and the commit.")
 else:
     print("".join(diff))

--- a/diff.py
+++ b/diff.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 import sys
-
+from difflib import unified_diff
 import docx2txt
 
 base_file = sys.argv[2] if len(sys.argv) > 2 else None
@@ -53,6 +53,11 @@ else:
         print(f"Error processing commit .txt file: {e}")
         sys.exit(1)
 
+# Use difflib to compare the two texts and print the differences
+def to_lines(text):
+    return [line + "\n" for line in text.splitlines()]
 
+print("".join(unified_diff(to_lines(base_text), to_lines(commit_text), fromfile=Path(base_file).name, tofile=Path(commit_to_diff).name)))
 
+print("Diff complete.")
 

--- a/diff.py
+++ b/diff.py
@@ -74,6 +74,7 @@ if first_diff_line is None:
     sys.exit(0)
 
 else:
+    diff = [first_diff_line] + list(diff)
     print("".join(diff))
 
 print("Diff complete.")

--- a/diff.py
+++ b/diff.py
@@ -45,5 +45,14 @@ if not commit_to_diff:
 elif not Path(commit_to_diff).suffix.lower() == ".txt" or not Path(commit_to_diff).is_file():
     print("Invalid commit file path, make sure the file exists and is a .txt file")
     sys.exit(1)
+else:
+    try:
+        with open(commit_to_diff, "r", encoding="utf-8", newline="\n") as commit_file:
+            commit_text = commit_file.read()
+    except Exception as e:
+        print(f"Error processing commit .txt file: {e}")
+        sys.exit(1)
+
+
 
 

--- a/sccs
+++ b/sccs
@@ -17,10 +17,13 @@ elif command == "open":
 
 elif command == "log":
     sys.exit(subprocess.run([sys.executable, os.path.join(script_directory, "log.py")] + sys.argv[1:]).returncode)
+
+elif command == "diff":
+    sys.exit(subprocess.run([sys.executable, os.path.join(script_directory, "diff.py")] + sys.argv[1:]).returncode)
     
 else: 
     print(f"Unknown command: {command}")
-    print("Invalid command. Please use 'init', 'commit', 'open', or 'log', along with required arguments.")
+    print("Invalid command. Please use 'init', 'commit', 'open', 'log', or 'diff', along with required arguments.")
     sys.exit(1)
 
-# If on MacOS / Linux, move this file, commit.py, init.py, open.py, and log.py to /usr/local/bin and make it executable with `chmod +x sccs`
+# If on MacOS / Linux, move this file, commit.py, init.py, open.py, log.py, and diff.py to /usr/local/bin and make it executable with `chmod +x sccs`

--- a/sccs.bat
+++ b/sccs.bat
@@ -26,6 +26,13 @@ if "%command%"=="log" (
     python "%script_directory%log.py" %*
     exit /b !errorlevel!
 )
+
+if "%command%"=="diff" (
+    set "script_directory=%~dp0"
+    python "%script_directory%diff.py" %*
+    exit /b !errorlevel!
+)
+
 echo Unknown command: %command%
-echo Invalid command. Please use "init", "commit", "open", or "log", along with required arguments
+echo Invalid command. Please use "init", "commit", "open", "log", or "diff", along with required arguments
 exit /b 1


### PR DESCRIPTION
# SCCS Diff

This PR focuses on a new command for the SCCS CLI, `sccs diff`. `sccs diff` compares a `.docx` file to a `.txt` file using the `difflib` library.

## SCCS

- Add tunnel for `sccs diff` command.

- Update fallback message. 

- Update commented instructions.

## SCCS.bat

- Add `batchfile` tunnel for `sccs diff` command.

- Update `batchfile` fallback message.

## Diff.py

- Check if both the base file and commit to compare exist and are the correct file type. (`.docx`, `.txt`)

- Open base `.docx` file and convert it to plain text.

- Open `.txt` commit file and store the plain text.

- Use `difflib` to compare diff.

- Check if the strings are actually different.

- Use `unified_diff` to compare the two plain text strings, and print the diff.