### PR TITLE
Feat/snapshot on commit

### DIFF
--- a/commit.py
+++ b/commit.py
@@ -85,9 +85,9 @@ with open(os.path.join(directory_path, ".sccs", "commits", "txt-commits", f"{sha
 shutil.copy2(os.path.join(directory_path, Path(path).name) , os.path.join(directory_path, ".sccs", "commits", "docx-commits", f"{sha_hash}.docx"))
 
 # Update history
-history["latest_commit"] = f"{sha_hash}.txt"
+history["latest_commit"] = f"{sha_hash}"
 history["latest_commit_number"] = history.get("latest_commit_number", 0) + 1
-history["commit_order"][str(history["latest_commit_number"])] = f"{sha_hash}.txt"
+history["commit_order"][str(history["latest_commit_number"])] = f"{sha_hash}"
 with open(history_path, "w", encoding="utf-8", newline="\n") as history_file:
     json.dump(history, history_file, indent=4)
 
@@ -100,7 +100,7 @@ if not Path(commit_messages_path).is_file():
 with open(commit_messages_path, "r", encoding="utf-8", newline="\n") as commit_messages_file:
     messages = json.load(commit_messages_file)
 
-messages[f"{sha_hash}.txt"] = f"{commit_message}"
+messages[f"{sha_hash}"] = f"{commit_message}"
 
 with open(commit_messages_path, "w", encoding="utf-8", newline="\n") as commit_messages_file:
     json.dump(messages, commit_messages_file, indent=4)
@@ -114,7 +114,7 @@ if not Path(commit_log_path).is_file():
 with open(commit_log_path, "r", encoding="utf-8", newline="\n") as commit_log_file:
     log = json.load(commit_log_file)
 
-log[f"{sha_hash}.txt"] = {
+log[f"{sha_hash}"] = {
     "timestamp": timestamp,
     "author": f"{name} <{email}>",
     "message": commit_message

--- a/commit.py
+++ b/commit.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+import shutil
 import sys
 import docx2txt 
 import hashlib
@@ -78,8 +79,10 @@ with open(history_path, "r", encoding="utf-8", newline="\n") as history_file:
 sha_hash = hashlib.sha256(f'{timestamp}/{commit_message}/{name}/{email}/{parent_hash}'.encode()).hexdigest()
 
 # Write .txt file
-with open(os.path.join(directory_path, ".sccs", "commits", f"{sha_hash}.txt"), "w", encoding="utf-8", newline="\n") as f:
+with open(os.path.join(directory_path, ".sccs", "commits", "txt-commits", f"{sha_hash}.txt"), "w", encoding="utf-8", newline="\n") as f:
     f.write(commit)
+
+shutil.copy2(os.path.join(directory_path, Path(path).name) , os.path.join(directory_path, ".sccs", "commits", "docx-commits", f"{sha_hash}.docx"))
 
 # Update history
 history["latest_commit"] = f"{sha_hash}.txt"

--- a/init.py
+++ b/init.py
@@ -67,7 +67,7 @@ history_data = {
     "latest_commit": f"{sha_hash}",
     "latest_commit_number": 1,
     "commit_order": {
-        "1": f"{sha_hash}.txt"
+        "1": f"{sha_hash}"
     }
 }
 

--- a/init.py
+++ b/init.py
@@ -50,12 +50,17 @@ os.makedirs(directory_path, exist_ok=True)
 shutil.move(path, directory_path)
 os.makedirs(os.path.join(directory_path, ".sccs"), exist_ok=True)
 os.makedirs(os.path.join(directory_path, ".sccs", "commits"), exist_ok=True)
+os.makedirs(os.path.join(directory_path, ".sccs", "commits", "txt-commits"), exist_ok=True)
+os.makedirs(os.path.join(directory_path, ".sccs", "commits", "docx-commits"), exist_ok=True)
 os.makedirs(os.path.join(directory_path, ".sccs", "history"), exist_ok=True)
 os.makedirs(os.path.join(directory_path, ".sccs", "commit_messages"), exist_ok=True)
 os.makedirs(os.path.join(directory_path, ".sccs", "config"), exist_ok=True)
 # Add info to the directories, JSON
-with open(os.path.join(directory_path, ".sccs", "commits", f"{sha_hash}.txt"), "w", encoding="utf-8", newline="\n") as f:
+with open(os.path.join(directory_path, ".sccs", "commits", "txt-commits", f"{sha_hash}.txt"), "w", encoding="utf-8", newline="\n") as f:
     f.write(docx_to_txt)
+
+shutil.copy2(os.path.join(directory_path, Path(path).name) , os.path.join(directory_path, ".sccs", "commits", "docx-commits", f"{sha_hash}.docx"))
+    
 
 history_data = {
     "initial_commit": f"{sha_hash}.txt",

--- a/init.py
+++ b/init.py
@@ -63,8 +63,8 @@ shutil.copy2(os.path.join(directory_path, Path(path).name), os.path.join(directo
     
 
 history_data = {
-    "initial_commit": f"{sha_hash}.txt",
-    "latest_commit": f"{sha_hash}.txt",
+    "initial_commit": f"{sha_hash}",
+    "latest_commit": f"{sha_hash}",
     "latest_commit_number": 1,
     "commit_order": {
         "1": f"{sha_hash}.txt"
@@ -75,7 +75,7 @@ with open(os.path.join(directory_path, ".sccs", "history", "commit_history.json"
     json.dump(history_data, f, indent=4)
 
 log_data = {
-    f"{sha_hash}.txt": {
+    f"{sha_hash}": {
         "timestamp": timestamp,
         "author": f"{name} <{email}>",
         "message": initial_commit_message
@@ -86,7 +86,7 @@ with open(os.path.join(directory_path, ".sccs", "history", "commit_log.json"), "
     json.dump(log_data, f, indent=4)
 
 commit_message_data = {
-    f"{sha_hash}.txt": initial_commit_message
+    f"{sha_hash}": initial_commit_message
 }
 
 with open(os.path.join(directory_path, ".sccs", "commit_messages", "commit_messages.json"), "w", encoding="utf-8", newline="\n") as f:

--- a/init.py
+++ b/init.py
@@ -59,7 +59,7 @@ os.makedirs(os.path.join(directory_path, ".sccs", "config"), exist_ok=True)
 with open(os.path.join(directory_path, ".sccs", "commits", "txt-commits", f"{sha_hash}.txt"), "w", encoding="utf-8", newline="\n") as f:
     f.write(docx_to_txt)
 
-shutil.copy2(os.path.join(directory_path, Path(path).name) , os.path.join(directory_path, ".sccs", "commits", "docx-commits", f"{sha_hash}.docx"))
+shutil.copy2(os.path.join(directory_path, Path(path).name), os.path.join(directory_path, ".sccs", "commits", "docx-commits", f"{sha_hash}.docx"))
     
 
 history_data = {

--- a/open.py
+++ b/open.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 from docx import Document
 import sys
@@ -44,16 +45,11 @@ if not Path(commit_path).is_file() or Path(commit_path).suffix.lower() != ".docx
     print("Invalid commit file path, make sure the file exists and is a .docx file")
     sys.exit(1)
 
-with open(commit_path, 'r') as file:
-    commit = file.read()
-document = Document()
-document.add_paragraph(commit)
-
 confirm = input(f"Are you sure you want to overwrite '{os.path.basename(path)}' with the contents of '{os.path.basename(commit_path)}'?\nThis action will replace the current content of the .docx file. (Y/N): ").strip().lower()
 if confirm != 'y':
     print("Update canceled.")
     sys.exit(0)
 
-document.save(path)
+shutil.copy2(commit_path, path)
 
 print(f"File '{os.path.basename(path)}' has been updated with the contents of '{os.path.basename(commit_path)}'.")

--- a/open.py
+++ b/open.py
@@ -50,6 +50,10 @@ if confirm != 'y':
     print("Update canceled.")
     sys.exit(0)
 
+if Path(path).exists() and Path(commit_path).exists() and os.path.samefile(path, commit_path):
+    print("The commit file is the same as the current file. No changes will be made.")
+    sys.exit(0)
+
 shutil.copy2(commit_path, path)
 
 print(f"File '{os.path.basename(path)}' has been updated with the contents of '{os.path.basename(commit_path)}'.")

--- a/open.py
+++ b/open.py
@@ -1,7 +1,5 @@
 import os
 import shutil
-
-from docx import Document
 import sys
 from pathlib import Path
 

--- a/open.py
+++ b/open.py
@@ -38,10 +38,10 @@ if not Path(path).is_file() or Path(path).suffix.lower() != ".docx":
     sys.exit(1)
 
 # Get user inputted commit path
-commit_path = input("Enter the path to the commit file (.txt): ")
+commit_path = input("Enter the path to the commit file (.docx): ")
 
-if not Path(commit_path).is_file() or Path(commit_path).suffix.lower() != ".txt":
-    print("Invalid commit file path, make sure the file exists and is a .txt file")
+if not Path(commit_path).is_file() or Path(commit_path).suffix.lower() != ".docx":
+    print("Invalid commit file path, make sure the file exists and is a .docx file")
     sys.exit(1)
 
 with open(commit_path, 'r') as file:


### PR DESCRIPTION
# Snapshot `.docx` on Commit 

This PR focuses on saving earlier version of the `.docx` for easier restorations.

## Init.py

- Create sub-directories `txt-commits` and `docx-commits`.

- Copy the initial `.docx` into `docx-commits`, named `{sha_hash}.docx`.

## Commit.py

- Copy the current `.docx` at the time of the commit to `docx-commits`, named `{sha_hash}.docx`.

## Open.py

- Rewrite the utilized version of the `.docx` with the selected commit file.