### PR TITLE
Feat/commands inside dir

### DIFF
--- a/commit.py
+++ b/commit.py
@@ -71,7 +71,6 @@ if not Path(path).is_file():
 try: 
     commit = docx2txt.process(path)
     with open(path, "rb") as f:
-        hashed_file = hashlib.sha256(f.read()).hexdigest()
         hasher = hashlib.sha256()
         for chunk in iter(lambda: f.read(65536), b""):
             hasher.update(chunk)

--- a/commit.py
+++ b/commit.py
@@ -11,56 +11,58 @@ directory_path = os.getcwd()
 
 path = os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx")
 
-if not Path(os.path.join(directory_path, ".sccs")).is_dir():
+sccs_dir = os.path.join(directory_path, ".sccs")
+
+if not Path(sccs_dir).is_dir():
     print("This file has not been initialized with SCCS.")
     print("Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(directory_path, ".sccs", "commit_file_hash")).is_dir():
+if not Path(os.path.join(sccs_dir, "commit_file_hash")).is_dir():
     print("Commit file hash directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(directory_path, ".sccs", "commit_file_hash.json")).is_file():
+if not Path(os.path.join(sccs_dir, "commit_file_hash.json")).is_file():
     print("Commit file hash JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(directory_path, ".sccs", "commit_messages")).is_dir():
+if not Path(os.path.join(sccs_dir, "commit_messages")).is_dir():
     print("Commit messages directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(directory_path, ".sccs", "commit_messages.json")).is_file():
+if not Path(os.path.join(sccs_dir, "commit_messages.json")).is_file():
     print("Commit messages JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(directory_path, ".sccs", "commits")).is_dir():
+if not Path(os.path.join(sccs_dir, "commits")).is_dir():
     print("Commits directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(directory_path, ".sccs", "commits", "txt-commits")).is_dir():
+if not Path(os.path.join(sccs_dir, "commits", "txt-commits")).is_dir():
     print("Text commits directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(directory_path, ".sccs", "commits", "docx-commits")).is_dir():
+if not Path(os.path.join(sccs_dir, "commits", "docx-commits")).is_dir():
     print("Docx commits directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(directory_path, ".sccs", "config")).is_dir():
+if not Path(os.path.join(sccs_dir, "config")).is_dir():
     print("Config directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(directory_path, ".sccs", "config", "config.json")).is_file():
+if not Path(os.path.join(sccs_dir, "config", "config.json")).is_file():
     print("Config file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(directory_path, ".sccs", "history")).is_dir():
+if not Path(os.path.join(sccs_dir, "history")).is_dir():
     print("History directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(directory_path, ".sccs", "history", "commit_history.json")).is_file():
+if not Path(os.path.join(sccs_dir, "history", "commit_history.json")).is_file():
     print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(directory_path, ".sccs", "history", "commit_history.json")).is_file():
+if not Path(os.path.join(sccs_dir, "history", "commit_history.json")).is_file():
     print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 

--- a/commit.py
+++ b/commit.py
@@ -7,52 +7,20 @@ import hashlib
 from datetime import datetime
 import json
 
+directory_path = os.getcwd()
 
-# Get user inputted path argument
-path = sys.argv[2] if len(sys.argv) > 2 else None
+path = os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx")
 
-# Strip .docx extension from the file name to create a directory
-# Because sccs init moves the file into the directory, update the path to point to the moved file
-if path: 
-
-    directory_path = Path(path).with_suffix("")
-
-    # if directory basename = parent directory name (eg: user/file/file), use parent directory (eg: user/file).
-    if directory_path.name == directory_path.parent.name:
-        directory_path = directory_path.parent
-
-    # Set path correctly, whether it was correct in the first place or not
-    path = os.path.join(directory_path, os.path.basename(path))
-
-    if not Path(path).is_file():
-        print("File not found. Please provide a valid file path.")
-        sys.exit(1)
-else:
-    print("No file path provided")
-    sys.exit(1)
-
-# Check if the directory contains an SCCS initialization
-if not Path(os.path.join(directory_path, ".sccs")).is_dir():
-    print("This file has not been initialized with SCCS.")
-    print("Please run 'sccs init <file_path>' to initialize SCCS for this file.")
-    sys.exit(1)
-
-elif path and Path(path).suffix.lower() == ".docx" and Path(path).is_file():
-    try: 
-        commit = docx2txt.process(path)
-        with open(path, "rb") as f:
-            hashed_file = hashlib.sha256(f.read()).hexdigest()
-            hasher = hashlib.sha256()
-            for chunk in iter(lambda: f.read(65536), b""):
-                hasher.update(chunk)
-            hashed_file = hasher.hexdigest()
-    except Exception as e:
-        print(f"Error processing .docx file: {e}")
-        sys.exit(1)
-
-# if not, exit  
-else: 
-    print("Invalid file path, make sure the file exists and is a .docx file")
+try: 
+    commit = docx2txt.process(path)
+    with open(path, "rb") as f:
+        hashed_file = hashlib.sha256(f.read()).hexdigest()
+        hasher = hashlib.sha256()
+        for chunk in iter(lambda: f.read(65536), b""):
+            hasher.update(chunk)
+        hashed_file = hasher.hexdigest()
+except Exception as e:
+    print(f"Error processing .docx file: {e}")
     sys.exit(1)
 
 # Get name and email entered on init

--- a/commit.py
+++ b/commit.py
@@ -22,7 +22,7 @@ if not Path(os.path.join(sccs_dir, "commit_file_hash")).is_dir():
     print("Commit file hash directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(sccs_dir, "commit_file_hash.json")).is_file():
+if not Path(os.path.join(sccs_dir, "commit_file_hash", "commit_file_hash.json")).is_file():
     print("Commit file hash JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
@@ -30,7 +30,7 @@ if not Path(os.path.join(sccs_dir, "commit_messages")).is_dir():
     print("Commit messages directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(sccs_dir, "commit_messages.json")).is_file():
+if not Path(os.path.join(sccs_dir, "commit_messages", "commit_messages.json")).is_file():
     print("Commit messages JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 

--- a/commit.py
+++ b/commit.py
@@ -11,6 +11,65 @@ directory_path = os.getcwd()
 
 path = os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx")
 
+if not Path(os.path.join(directory_path, ".sccs")).is_dir():
+    print("This file has not been initialized with SCCS.")
+    print("Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(directory_path, ".sccs", "commit_file_hash")).is_dir():
+    print("Commit file hash directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(directory_path, ".sccs", "commit_file_hash.json")).is_file():
+    print("Commit file hash JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(directory_path, ".sccs", "commit_messages")).is_dir():
+    print("Commit messages directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(directory_path, ".sccs", "commit_messages.json")).is_file():
+    print("Commit messages JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(directory_path, ".sccs", "commits")).is_dir():
+    print("Commits directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(directory_path, ".sccs", "commits", "txt-commits")).is_dir():
+    print("Text commits directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(directory_path, ".sccs", "commits", "docx-commits")).is_dir():
+    print("Docx commits directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(directory_path, ".sccs", "config")).is_dir():
+    print("Config directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(directory_path, ".sccs", "config", "config.json")).is_file():
+    print("Config file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(directory_path, ".sccs", "history")).is_dir():
+    print("History directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(directory_path, ".sccs", "history", "commit_history.json")).is_file():
+    print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(directory_path, ".sccs", "history", "commit_history.json")).is_file():
+    print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(path).is_file():
+    print("Docx file not found. Re-initialize SCCS for this file with 'sccs init <file_path>'")
+    sys.exit(1)
+
+
+
 try: 
     commit = docx2txt.process(path)
     with open(path, "rb") as f:

--- a/commit.py
+++ b/commit.py
@@ -62,10 +62,6 @@ if not Path(os.path.join(sccs_dir, "history", "commit_history.json")).is_file():
     print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(sccs_dir, "history", "commit_history.json")).is_file():
-    print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
-    sys.exit(1)
-
 if not Path(path).is_file():
     print("Docx file not found. Re-initialize SCCS for this file with 'sccs init <file_path>'")
     sys.exit(1)

--- a/diff.py
+++ b/diff.py
@@ -30,7 +30,7 @@ if not Path(os.path.join(sccs_dir, "commit_file_hash")).is_dir():
     print("Commit file hash directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(sccs_dir, "commit_file_hash.json")).is_file():
+if not Path(os.path.join(sccs_dir, "commit_file_hash", "commit_file_hash.json")).is_file():
     print("Commit file hash JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
@@ -38,7 +38,7 @@ if not Path(os.path.join(sccs_dir, "commit_messages")).is_dir():
     print("Commit messages directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(sccs_dir, "commit_messages.json")).is_file():
+if not Path(os.path.join(sccs_dir, "commit_messages", "commit_messages.json")).is_file():
     print("Commit messages JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 

--- a/diff.py
+++ b/diff.py
@@ -13,6 +13,14 @@ base_file = os.path.join(directory_path, f"{os.path.basename(directory_path)}.do
 
 sccs_dir = os.path.join(directory_path, ".sccs")
 
+if not commit_to_diff:
+    print("No commit file specified.")
+    sys.exit(1)
+
+if not Path(commit_to_diff).is_file():
+    print("Commit file not found. Please provide a valid commit file path.")
+    sys.exit(1)
+
 if not Path(sccs_dir).is_dir():
     print("This file has not been initialized with SCCS.")
     print("Please run 'sccs init <file_path>' to initialize SCCS for this file.")

--- a/diff.py
+++ b/diff.py
@@ -21,6 +21,10 @@ if not Path(commit_to_diff).is_file():
     print("Commit file not found. Please provide a valid commit file path.")
     sys.exit(1)
 
+if Path(commit_to_diff).suffix != ".txt":
+    print("Commit file is not a .txt file. Please provide a valid .txt commit file.")
+    sys.exit(1)
+
 if not Path(sccs_dir).is_dir():
     print("This file has not been initialized with SCCS.")
     print("Please run 'sccs init <file_path>' to initialize SCCS for this file.")

--- a/diff.py
+++ b/diff.py
@@ -21,7 +21,7 @@ if not Path(commit_to_diff).is_file():
     print("Commit file not found. Please provide a valid commit file path.")
     sys.exit(1)
 
-if Path(commit_to_diff).suffix != ".txt":
+if Path(commit_to_diff).suffix.lower() != ".txt":
     print("Commit file is not a .txt file. Please provide a valid .txt commit file.")
     sys.exit(1)
 
@@ -87,8 +87,7 @@ except Exception as e:
     sys.exit(1)
 
 try: 
-    with open(base_file, "r", encoding="utf-8", newline="\n") as base_file_obj:
-        base_text = base_file_obj.read()
+    base_text = docx2txt.process(base_file)
 
 except Exception as e:
     print(f"Error processing base .docx file: {e}")       

--- a/diff.py
+++ b/diff.py
@@ -70,10 +70,6 @@ if not Path(os.path.join(sccs_dir, "history", "commit_history.json")).is_file():
     print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(sccs_dir, "history", "commit_history.json")).is_file():
-    print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
-    sys.exit(1)
-
 if not Path(base_file).is_file():
     print("Docx file not found. Re-initialize SCCS for this file with 'sccs init <file_path>'")
     sys.exit(1)

--- a/diff.py
+++ b/diff.py
@@ -4,51 +4,87 @@ import sys
 from difflib import unified_diff
 import docx2txt
 
-base_file = sys.argv[2] if len(sys.argv) > 2 else None
-commit_to_diff = sys.argv[3] if len(sys.argv) > 3 else None
+# base_file = sys.argv[2] if len(sys.argv) > 2 else None
+commit_to_diff = sys.argv[2] if len(sys.argv) > 2 else None 
 
-if base_file and commit_to_diff:
-    
-    directory_path = Path(base_file).with_suffix('')
-    if directory_path.name == directory_path.parent.name:
-        directory_path = directory_path.parent
-    
-    base_file = os.path.join(directory_path, os.path.basename(base_file))
+directory_path = os.getcwd()
 
-    if not Path(base_file).is_file():
-        print("Base file not found. Please provide a valid base file path.")
-        sys.exit(1)
-else:
-    print("Please provide both the base file path and the commit file path to compare.")
-    sys.exit(1)
+base_file = os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx")
 
-if not Path(os.path.join(directory_path, ".sccs")).is_dir():
+sccs_dir = os.path.join(directory_path, ".sccs")
+
+if not Path(sccs_dir).is_dir():
     print("This file has not been initialized with SCCS.")
     print("Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-elif base_file and Path(base_file).suffix.lower() == ".docx" and Path(base_file).is_file():
-    try: 
-        base_text = docx2txt.process(base_file)
-    except Exception as e:
-        print(f"Error processing base .docx file: {e}")
-        sys.exit(1)
-
-else: 
-    print("Invalid base file path, make sure the file exists and is a .docx file")
+if not Path(os.path.join(sccs_dir, "commit_file_hash")).is_dir():
+    print("Commit file hash directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-
-if Path(commit_to_diff).suffix.lower() != ".txt" or not Path(commit_to_diff).is_file():
-    print("Invalid commit file path, make sure the file exists and is a .txt file")
+if not Path(os.path.join(sccs_dir, "commit_file_hash.json")).is_file():
+    print("Commit file hash JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
-else:
-    try:
-        with open(commit_to_diff, "r", encoding="utf-8", newline="\n") as commit_file:
-            commit_text = commit_file.read()
-    except Exception as e:
-        print(f"Error processing commit .txt file: {e}")
-        sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "commit_messages")).is_dir():
+    print("Commit messages directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "commit_messages.json")).is_file():
+    print("Commit messages JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "commits")).is_dir():
+    print("Commits directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "commits", "txt-commits")).is_dir():
+    print("Text commits directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "commits", "docx-commits")).is_dir():
+    print("Docx commits directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "config")).is_dir():
+    print("Config directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "config", "config.json")).is_file():
+    print("Config file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "history")).is_dir():
+    print("History directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "history", "commit_history.json")).is_file():
+    print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "history", "commit_history.json")).is_file():
+    print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(base_file).is_file():
+    print("Docx file not found. Re-initialize SCCS for this file with 'sccs init <file_path>'")
+    sys.exit(1)
+
+try:
+    with open(commit_to_diff, "r", encoding="utf-8", newline="\n") as commit_file:
+        commit_text = commit_file.read()
+
+except Exception as e:
+    print(f"Error processing commit .txt file: {e}")       
+    sys.exit(1)
+
+try: 
+    with open(base_file, "r", encoding="utf-8", newline="\n") as base_file_obj:
+        base_text = base_file_obj.read()
+
+except Exception as e:
+    print(f"Error processing base .docx file: {e}")       
+    sys.exit(1)
 
 # Use difflib to compare the two texts and print the differences
 def to_lines(text):

--- a/log.py
+++ b/log.py
@@ -20,7 +20,7 @@ if not Path(os.path.join(sccs_dir, "commit_file_hash")).is_dir():
     print("Commit file hash directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(sccs_dir, "commit_file_hash.json")).is_file():
+if not Path(os.path.join(sccs_dir, "commit_file_hash", "commit_file_hash.json")).is_file():
     print("Commit file hash JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
@@ -28,7 +28,7 @@ if not Path(os.path.join(sccs_dir, "commit_messages")).is_dir():
     print("Commit messages directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(sccs_dir, "commit_messages.json")).is_file():
+if not Path(os.path.join(sccs_dir, "commit_messages", "commit_messages.json")).is_file():
     print("Commit messages JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 

--- a/log.py
+++ b/log.py
@@ -3,33 +3,69 @@ from pathlib import Path
 import os
 import sys
 
-path = sys.argv[2] if len(sys.argv) > 2 else None
 
-if path: 
 
-    directory_path = Path(path).with_suffix("")
+directory_path = os.getcwd()
 
-    # if directory basename = parent directory name (eg: user/file/file), use parent directory (eg: user/file).
-    if directory_path.name == directory_path.parent.name:
-        directory_path = directory_path.parent
+path = os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx")
 
-    # Set path correctly, whether it was correct in the first place or not
-    path = os.path.join(directory_path, os.path.basename(path))
+sccs_dir = os.path.join(directory_path, ".sccs")
 
-    if not Path(path).is_file():
-        print("File not found. Please provide a valid file path.")
-        sys.exit(1)
-else:
-    print("No file path provided")
-    sys.exit(1)
-
-if not Path(os.path.join(directory_path, ".sccs")).is_dir():
+if not Path(sccs_dir).is_dir():
     print("This file has not been initialized with SCCS.")
     print("Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-elif not path or Path(path).suffix.lower() != ".docx" or not Path(path).is_file():
-    print("Invalid file path, make sure the file exists and is a .docx file")
+if not Path(os.path.join(sccs_dir, "commit_file_hash")).is_dir():
+    print("Commit file hash directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "commit_file_hash.json")).is_file():
+    print("Commit file hash JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "commit_messages")).is_dir():
+    print("Commit messages directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "commit_messages.json")).is_file():
+    print("Commit messages JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "commits")).is_dir():
+    print("Commits directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "commits", "txt-commits")).is_dir():
+    print("Text commits directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "commits", "docx-commits")).is_dir():
+    print("Docx commits directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "config")).is_dir():
+    print("Config directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "config", "config.json")).is_file():
+    print("Config file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "history")).is_dir():
+    print("History directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "history", "commit_history.json")).is_file():
+    print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "history", "commit_history.json")).is_file():
+    print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(path).is_file():
+    print("Docx file not found. Re-initialize SCCS for this file with 'sccs init <file_path>'")
     sys.exit(1)
 
 # Get JSON log data

--- a/log.py
+++ b/log.py
@@ -60,10 +60,6 @@ if not Path(os.path.join(sccs_dir, "history", "commit_history.json")).is_file():
     print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(sccs_dir, "history", "commit_history.json")).is_file():
-    print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
-    sys.exit(1)
-
 if not Path(path).is_file():
     print("Docx file not found. Re-initialize SCCS for this file with 'sccs init <file_path>'")
     sys.exit(1)

--- a/open.py
+++ b/open.py
@@ -3,37 +3,100 @@ import shutil
 import sys
 from pathlib import Path
 
-# Get user inputted path argument
-path = sys.argv[2] if len(sys.argv) > 2 else None
+# # Get user inputted path argument
+# path = sys.argv[2] if len(sys.argv) > 2 else None
 
-# Check if the path is provided
-if path: 
+# # Check if the path is provided
+# if path: 
 
-    directory_path = Path(path).with_suffix("")
+#     directory_path = Path(path).with_suffix("")
 
-    # if directory basename = parent directory name (eg: user/file/file), use parent directory (eg: user/file).
-    if directory_path.name == directory_path.parent.name:
-        directory_path = directory_path.parent
+#     # if directory basename = parent directory name (eg: user/file/file), use parent directory (eg: user/file).
+#     if directory_path.name == directory_path.parent.name:
+#         directory_path = directory_path.parent
 
-    # Set path correctly, whether it was correct in the first place or not
-    path = os.path.join(directory_path, os.path.basename(path))
+#     # Set path correctly, whether it was correct in the first place or not
+#     path = os.path.join(directory_path, os.path.basename(path))
 
-    if not Path(path).is_file():
-        print("Invalid file path, make sure the file exists and is a .docx file")
-        sys.exit(1)
-else:
-    print("No file path provided")
-    sys.exit(1)
+#     if not Path(path).is_file():
+#         print("Invalid file path, make sure the file exists and is a .docx file")
+#         sys.exit(1)
+# else:
+#     print("No file path provided")
+#     sys.exit(1)
 
-# Check if the directory contains an SCCS initialization
-if not Path(os.path.join(directory_path, ".sccs")).is_dir():
+# # Check if the directory contains an SCCS initialization
+# if not Path(os.path.join(directory_path, ".sccs")).is_dir():
+#     print("This file has not been initialized with SCCS.")
+#     print("Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+#     sys.exit(1)
+    
+# # Check if the path ends with .docx and exists
+# if not Path(path).is_file() or Path(path).suffix.lower() != ".docx":
+#     print("Invalid file path, make sure the file exists and is a .docx file")
+#     sys.exit(1)
+
+directory_path = os.getcwd()
+
+path = os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx")
+
+sccs_dir = os.path.join(directory_path, ".sccs")
+
+if not Path(sccs_dir).is_dir():
     print("This file has not been initialized with SCCS.")
     print("Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
-    
-# Check if the path ends with .docx and exists
-if not Path(path).is_file() or Path(path).suffix.lower() != ".docx":
-    print("Invalid file path, make sure the file exists and is a .docx file")
+
+if not Path(os.path.join(sccs_dir, "commit_file_hash")).is_dir():
+    print("Commit file hash directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "commit_file_hash.json")).is_file():
+    print("Commit file hash JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "commit_messages")).is_dir():
+    print("Commit messages directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "commit_messages.json")).is_file():
+    print("Commit messages JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "commits")).is_dir():
+    print("Commits directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "commits", "txt-commits")).is_dir():
+    print("Text commits directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "commits", "docx-commits")).is_dir():
+    print("Docx commits directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "config")).is_dir():
+    print("Config directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "config", "config.json")).is_file():
+    print("Config file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "history")).is_dir():
+    print("History directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "history", "commit_history.json")).is_file():
+    print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "history", "commit_history.json")).is_file():
+    print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(path).is_file():
+    print("Docx file not found. Re-initialize SCCS for this file with 'sccs init <file_path>'")
     sys.exit(1)
 
 # Get user inputted commit path

--- a/open.py
+++ b/open.py
@@ -58,10 +58,6 @@ if not Path(os.path.join(sccs_dir, "history", "commit_history.json")).is_file():
     print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(sccs_dir, "history", "commit_history.json")).is_file():
-    print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
-    sys.exit(1)
-
 if not Path(path).is_file():
     print("Docx file not found. Re-initialize SCCS for this file with 'sccs init <file_path>'")
     sys.exit(1)

--- a/open.py
+++ b/open.py
@@ -3,39 +3,6 @@ import shutil
 import sys
 from pathlib import Path
 
-# # Get user inputted path argument
-# path = sys.argv[2] if len(sys.argv) > 2 else None
-
-# # Check if the path is provided
-# if path: 
-
-#     directory_path = Path(path).with_suffix("")
-
-#     # if directory basename = parent directory name (eg: user/file/file), use parent directory (eg: user/file).
-#     if directory_path.name == directory_path.parent.name:
-#         directory_path = directory_path.parent
-
-#     # Set path correctly, whether it was correct in the first place or not
-#     path = os.path.join(directory_path, os.path.basename(path))
-
-#     if not Path(path).is_file():
-#         print("Invalid file path, make sure the file exists and is a .docx file")
-#         sys.exit(1)
-# else:
-#     print("No file path provided")
-#     sys.exit(1)
-
-# # Check if the directory contains an SCCS initialization
-# if not Path(os.path.join(directory_path, ".sccs")).is_dir():
-#     print("This file has not been initialized with SCCS.")
-#     print("Please run 'sccs init <file_path>' to initialize SCCS for this file.")
-#     sys.exit(1)
-    
-# # Check if the path ends with .docx and exists
-# if not Path(path).is_file() or Path(path).suffix.lower() != ".docx":
-#     print("Invalid file path, make sure the file exists and is a .docx file")
-#     sys.exit(1)
-
 directory_path = os.getcwd()
 
 path = os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx")

--- a/open.py
+++ b/open.py
@@ -18,7 +18,7 @@ if not Path(os.path.join(sccs_dir, "commit_file_hash")).is_dir():
     print("Commit file hash directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(sccs_dir, "commit_file_hash.json")).is_file():
+if not Path(os.path.join(sccs_dir, "commit_file_hash", "commit_file_hash.json")).is_file():
     print("Commit file hash JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
@@ -26,7 +26,7 @@ if not Path(os.path.join(sccs_dir, "commit_messages")).is_dir():
     print("Commit messages directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(sccs_dir, "commit_messages.json")).is_file():
+if not Path(os.path.join(sccs_dir, "commit_messages", "commit_messages.json")).is_file():
     print("Commit messages JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 

--- a/status.py
+++ b/status.py
@@ -19,7 +19,7 @@ if not Path(os.path.join(sccs_dir, "commit_file_hash")).is_dir():
     print("Commit file hash directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(sccs_dir, "commit_file_hash.json")).is_file():
+if not Path(os.path.join(sccs_dir, "commit_file_hash", "commit_file_hash.json")).is_file():
     print("Commit file hash JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
@@ -27,7 +27,7 @@ if not Path(os.path.join(sccs_dir, "commit_messages")).is_dir():
     print("Commit messages directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(sccs_dir, "commit_messages.json")).is_file():
+if not Path(os.path.join(sccs_dir, "commit_messages", "commit_messages.json")).is_file():
     print("Commit messages JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 

--- a/status.py
+++ b/status.py
@@ -59,10 +59,6 @@ if not Path(os.path.join(sccs_dir, "history", "commit_history.json")).is_file():
     print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-if not Path(os.path.join(sccs_dir, "history", "commit_history.json")).is_file():
-    print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
-    sys.exit(1)
-
 if not Path(path).is_file():
     print("Docx file not found. Re-initialize SCCS for this file with 'sccs init <file_path>'")
     sys.exit(1)

--- a/status.py
+++ b/status.py
@@ -4,43 +4,69 @@ import sys
 import hashlib
 import json
 
-# Get user inputted path argument
-path = sys.argv[2] if len(sys.argv) > 2 else None
+directory_path = os.getcwd()
 
-# Strip .docx extension from the file name to create a directory
-# Because sccs init moves the file into the directory, update the path to point to the moved file
-if path: 
+path = os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx")
 
-    directory_path = Path(path).with_suffix("")
+sccs_dir = os.path.join(directory_path, ".sccs")
 
-    # if directory basename = parent directory name (eg: user/file/file), use parent directory (eg: user/file).
-    if directory_path.name == directory_path.parent.name:
-        directory_path = directory_path.parent
-
-    if Path(os.path.join(directory_path, ".sccs")).is_dir():
-
-    # Set path correctly, whether it was correct in the first place or not
-        path = os.path.join(directory_path, os.path.basename(path))
-
-    else: 
-        print("This file has not been initialized with SCCS.")
-        print("Please run 'sccs init <file_path>' to initialize SCCS for this file.")
-        sys.exit(1)
-
-    if not Path(path).is_file():
-        print("File not found. Please provide a valid file path.")
-        sys.exit(1)
-else:
-    print("No file path provided")
-    sys.exit(1)
-if not path or Path(path).suffix.lower() != ".docx" or not Path(path).is_file():
-    print("Invalid file path, make sure the file exists and is a .docx file")
+if not Path(sccs_dir).is_dir():
+    print("This file has not been initialized with SCCS.")
+    print("Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-else: 
-    print("Invalid file path, make sure the file exists and is a .docx file")
+if not Path(os.path.join(sccs_dir, "commit_file_hash")).is_dir():
+    print("Commit file hash directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
-    
+
+if not Path(os.path.join(sccs_dir, "commit_file_hash.json")).is_file():
+    print("Commit file hash JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "commit_messages")).is_dir():
+    print("Commit messages directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "commit_messages.json")).is_file():
+    print("Commit messages JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "commits")).is_dir():
+    print("Commits directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "commits", "txt-commits")).is_dir():
+    print("Text commits directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "commits", "docx-commits")).is_dir():
+    print("Docx commits directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "config")).is_dir():
+    print("Config directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "config", "config.json")).is_file():
+    print("Config file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "history")).is_dir():
+    print("History directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "history", "commit_history.json")).is_file():
+    print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(os.path.join(sccs_dir, "history", "commit_history.json")).is_file():
+    print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    sys.exit(1)
+
+if not Path(path).is_file():
+    print("Docx file not found. Re-initialize SCCS for this file with 'sccs init <file_path>'")
+    sys.exit(1)
+
 try:
     with open(path, "rb") as f:
         hasher = hashlib.sha256()
@@ -50,9 +76,6 @@ try:
 except Exception as e:
     print(f"Error processing .docx file: {e}")
     sys.exit(1)
-
-# if not, exit  
-
 
 # get the latest commit filename hash from commit history
 history_path = os.path.join(directory_path, ".sccs", "history", "commit_history.json")


### PR DESCRIPTION
# Run Commands Inside Directory #15

This PR focuses on allowing users to run commands without specifying the path of the `.docx`.

## All Files

- Check that `.sccs` has the right files and layout.

- Get the CWD using `os.getcwd()`.

- Search for `.sccs` inside the CWD, along with required files.
