### PR TITLE
fix: make lines same length

### DIFF
--- a/log.py
+++ b/log.py
@@ -25,5 +25,5 @@ for entry in log_data:
         f"Author: {log_data[entry]['author']}\n"
         f"Date: {log_data[entry]['timestamp']}\n"
         f"Message: {log_data[entry]['message']}\n"
-        "-----------------------------"
+        "------------------------------"
     )


### PR DESCRIPTION
# What does this PR do? #Issue (Link related issue if applicable)

This PR makes the second line of `-`s  1 longer to repair inconsistency.

## Log.py

The second line of `-`s is changed to match the first.

## Type of Change

- [ ] Bugfix