### PR TITLE
fix: sccs file path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ pip install -r requirements.txt
 MacOS / Linux
 
 ```bash
-# Make SCCS file executable
-sudo chmod +x sccs
-
 # Copy all repo CLI files to /usr/local/bin/
 sudo cp commit.py diff.py help.py init.py default_css_styles.py log.py open.py status.py sccs
+
+# Make SCCS file executable
+sudo chmod +x /usr/local/bin/sccs
 ```
 
 Windows


### PR DESCRIPTION
# Update the path of SCCS file in README

Updated the README to correct the path for SCCS file execution.

## README.md

Updated the README to correct the path for SCCS file execution.

## Type of Change

- [ ] Documentation