### PR TITLE
Fix/return str or bs4 soup

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -88,13 +88,12 @@ def get_data_number(tag_list):
                 data_number.add(parsed_tag.get('data-number'))
     return data_number
 
-docx_current_version_list = tags_to_list(number_tags(remove_inline_semantics(docx_current_version_html)))
+docx_current_version_list = tags_to_list(number_tags(remove_inline_semantics(BeautifulSoup(docx_current_version_html, "html.parser"))))
 
-commit_list = tags_to_list(number_tags(remove_inline_semantics(commit_html)))
+commit_list = tags_to_list(number_tags(remove_inline_semantics(BeautifulSoup(commit_html, "html.parser"))))
 
-opcodes = difflib.SequenceMatcher(None, tags_to_list(remove_inline_semantics(commit_html)), tags_to_list(remove_inline_semantics(docx_current_version_html))).get_opcodes()
-
-redline = BeautifulSoup(number_tags(remove_inline_semantics(commit_html)), "html.parser")
+opcodes = difflib.SequenceMatcher(None, tags_to_list(remove_inline_semantics(BeautifulSoup(commit_html, "html.parser"))), tags_to_list(remove_inline_semantics(BeautifulSoup(docx_current_version_html, "html.parser")))).get_opcodes()
+redline = BeautifulSoup(number_tags(remove_inline_semantics(BeautifulSoup(commit_html, "html.parser"))), "html.parser")
 
 def delete_tag(html, old_changed_strings):
     old_data_numbers = get_data_number(old_changed_strings)

--- a/diff.py
+++ b/diff.py
@@ -88,15 +88,15 @@ def get_data_number(tag_list):
                 data_number.add(parsed_tag.get('data-number'))
     return data_number
 
-bs4_docx_current_version_html = BeautifulSoup(docx_current_version_html, "html.parser")
+bs4_docx_current_version_soup = BeautifulSoup(docx_current_version_html, "html.parser")
 
-docx_current_version_list = tags_to_list(number_tags(remove_inline_semantics(bs4_docx_current_version_html)))
+docx_current_version_list = tags_to_list(number_tags(remove_inline_semantics(bs4_docx_current_version_soup)))
 
-bs4_commit_html = BeautifulSoup(commit_html, "html.parser")
-commit_list = tags_to_list(number_tags(remove_inline_semantics(bs4_commit_html)))
+bs4_commit_soup = BeautifulSoup(commit_html, "html.parser")
+commit_list = tags_to_list(number_tags(remove_inline_semantics(bs4_commit_soup)))
 
-opcodes = difflib.SequenceMatcher(None, tags_to_list(remove_inline_semantics(bs4_commit_html)), tags_to_list(remove_inline_semantics(bs4_docx_current_version_html))).get_opcodes()
-redline = number_tags(remove_inline_semantics(bs4_commit_html))
+opcodes = difflib.SequenceMatcher(None, tags_to_list(remove_inline_semantics(bs4_commit_soup)), tags_to_list(remove_inline_semantics(bs4_docx_current_version_soup))).get_opcodes()
+redline = number_tags(remove_inline_semantics(bs4_commit_soup))
 
 def delete_tag(html, old_changed_strings):
     old_data_numbers = get_data_number(old_changed_strings)

--- a/diff.py
+++ b/diff.py
@@ -90,10 +90,10 @@ def get_data_number(tag_list):
 
 bs4_docx_current_version_soup = BeautifulSoup(docx_current_version_html, "html.parser")
 
-docx_current_version_list = tags_to_list(number_tags(remove_inline_semantics(bs4_docx_current_version_soup)))
+docx_current_version_list = tags_to_list(number_tags(remove_inline_semantics(docx_current_version_html)))
 
 bs4_commit_soup = BeautifulSoup(commit_html, "html.parser")
-commit_list = tags_to_list(number_tags(remove_inline_semantics(bs4_commit_soup)))
+commit_list = tags_to_list(number_tags(remove_inline_semantics(commit_html)))
 
 opcodes = difflib.SequenceMatcher(None, tags_to_list(remove_inline_semantics(bs4_commit_soup)), tags_to_list(remove_inline_semantics(bs4_docx_current_version_soup))).get_opcodes()
 redline = number_tags(remove_inline_semantics(bs4_commit_soup))

--- a/diff.py
+++ b/diff.py
@@ -96,7 +96,7 @@ bs4_commit_html = BeautifulSoup(commit_html, "html.parser")
 commit_list = tags_to_list(number_tags(remove_inline_semantics(bs4_commit_html)))
 
 opcodes = difflib.SequenceMatcher(None, tags_to_list(remove_inline_semantics(bs4_commit_html)), tags_to_list(remove_inline_semantics(bs4_docx_current_version_html))).get_opcodes()
-redline = BeautifulSoup(number_tags(remove_inline_semantics(bs4_commit_html)), "html.parser")
+redline = number_tags(remove_inline_semantics(bs4_commit_html))
 
 def delete_tag(html, old_changed_strings):
     old_data_numbers = get_data_number(old_changed_strings)

--- a/diff.py
+++ b/diff.py
@@ -88,12 +88,15 @@ def get_data_number(tag_list):
                 data_number.add(parsed_tag.get('data-number'))
     return data_number
 
-docx_current_version_list = tags_to_list(number_tags(remove_inline_semantics(BeautifulSoup(docx_current_version_html, "html.parser"))))
+bs4_docx_current_version_html = BeautifulSoup(docx_current_version_html, "html.parser")
 
-commit_list = tags_to_list(number_tags(remove_inline_semantics(BeautifulSoup(commit_html, "html.parser"))))
+docx_current_version_list = tags_to_list(number_tags(remove_inline_semantics(bs4_docx_current_version_html)))
 
-opcodes = difflib.SequenceMatcher(None, tags_to_list(remove_inline_semantics(BeautifulSoup(commit_html, "html.parser"))), tags_to_list(remove_inline_semantics(BeautifulSoup(docx_current_version_html, "html.parser")))).get_opcodes()
-redline = BeautifulSoup(number_tags(remove_inline_semantics(BeautifulSoup(commit_html, "html.parser"))), "html.parser")
+bs4_commit_html = BeautifulSoup(commit_html, "html.parser")
+commit_list = tags_to_list(number_tags(remove_inline_semantics(bs4_commit_html)))
+
+opcodes = difflib.SequenceMatcher(None, tags_to_list(remove_inline_semantics(bs4_commit_html)), tags_to_list(remove_inline_semantics(bs4_docx_current_version_html))).get_opcodes()
+redline = BeautifulSoup(number_tags(remove_inline_semantics(bs4_commit_html)), "html.parser")
 
 def delete_tag(html, old_changed_strings):
     old_data_numbers = get_data_number(old_changed_strings)


### PR DESCRIPTION
# Str Passed to Func Instead of Bs4 #34 

This PR focuses on #34, were strings were being passed to a function requiring a BeautifulSoup object.

## Diff.py

- Create bs4_docx_current_version_html, bs4_commit_html which are Bs4 objects of docx_current_version_html and commit_html respectively.
- Use these new variables in place of their HTML version.

## Type of Change

- [ ] Bugfix