### PR TITLE
Feat/center html

### DIFF
--- a/default_css_styles.py
+++ b/default_css_styles.py
@@ -18,5 +18,16 @@ background-color: #fbb6c2;
 display: block;
 
 width: fit-content;
+
+.center {
+
+display: flex;
+
+justify-content: center;
+
+align-items: center;
+
+width: 50vw;
+
 }
 </style>"""

--- a/default_css_styles.py
+++ b/default_css_styles.py
@@ -27,9 +27,10 @@ display: flex;
 
 justify-content: center;
 
-align-items: center;
-
-width: 50vw;
-
 }
+
+.document {
+    width: 50%;
+}
+
 </style>"""

--- a/default_css_styles.py
+++ b/default_css_styles.py
@@ -19,6 +19,8 @@ display: block;
 
 width: fit-content;
 
+}
+
 .center {
 
 display: flex;

--- a/default_css_styles.py
+++ b/default_css_styles.py
@@ -29,8 +29,4 @@ justify-content: center;
 
 }
 
-.document {
-    width: 50%;
-}
-
 </style>"""

--- a/diff.py
+++ b/diff.py
@@ -178,4 +178,4 @@ for opcode in reversed(opcodes):
     if tag =="delete":
         redline = delete_tag(redline, old_changed_strings)
 with open("redline.html", "w", encoding="utf-8", newline="\n") as f:
-    f.write(f"{wrap_html(str(strip_number_attribute(redline)))}")
+    f.write(wrap_html(str(strip_number_attribute(redline))))

--- a/diff.py
+++ b/diff.py
@@ -89,7 +89,7 @@ def get_data_number(tag_list):
     return data_number
 
 def wrap_html(html):
-    return f"<!DOCTYPE html><html><head><meta charset='UTF-8'>{styles}</head><body><div class='center'><div>{html}</div></div></body></html>"
+    return f"<!DOCTYPE html><html><head><meta charset='UTF-8'>{styles}</head><body><div class='center'><div class='document'>{html}</div></div></body></html>"
 
 bs4_docx_current_version_soup = BeautifulSoup(docx_current_version_html, "html.parser")
 

--- a/diff.py
+++ b/diff.py
@@ -91,6 +91,8 @@ def get_data_number(tag_list):
 def wrap_html(html):
     return f"<!DOCTYPE html><html><head><meta charset='UTF-8'>{styles}</head><body><div class='center'>{html}</div></body></html>"
 
+bs4_docx_current_version_soup = BeautifulSoup(docx_current_version_html, "html.parser")
+
 docx_current_version_list = tags_to_list(number_tags(remove_inline_semantics(bs4_docx_current_version_soup)))
 
 bs4_commit_soup = BeautifulSoup(commit_html, "html.parser")

--- a/diff.py
+++ b/diff.py
@@ -98,7 +98,7 @@ docx_current_version_list = tags_to_list(number_tags(remove_inline_semantics(bs4
 bs4_commit_soup = BeautifulSoup(commit_html, "html.parser")
 commit_list = tags_to_list(number_tags(remove_inline_semantics(bs4_commit_soup)))
 
-opcodes = difflib.SequenceMatcher(None, tags_to_list(remove_inline_semantics(bs4_commit_soup)), tags_to_list(remove_inline_semantics(bs4_docx_current_version_soup))).get_opcodes()
+opcodes = difflib.SequenceMatcher(None, tags_to_list(remove_inline_semantics(BeautifulSoup(commit_html, "html.parser"))), tags_to_list(remove_inline_semantics(BeautifulSoup(docx_current_version_html, "html.parser")))).get_opcodes()
 redline = number_tags(remove_inline_semantics(bs4_commit_soup))
 
 def delete_tag(html, old_changed_strings):

--- a/diff.py
+++ b/diff.py
@@ -6,7 +6,7 @@ import mammoth
 import difflib
 from sccs_layout_check import check_sccs
 from default_css_styles import styles
-
+import copy
 
 
 commit_to_diff = sys.argv[2] if len(sys.argv) > 2 else None 
@@ -91,12 +91,15 @@ def get_data_number(tag_list):
 def wrap_html(html):
     return f"<!DOCTYPE html><html><head><meta charset='UTF-8'>{styles}</head><body><div class='center'><div>{html}</div></div></body></html>"
 
-docx_current_version_list = tags_to_list(number_tags(remove_inline_semantics(BeautifulSoup(docx_current_version_html, "html.parser"))))
+bs4_docx_current_version_soup = BeautifulSoup(docx_current_version_html, "html.parser")
 
-commit_list = tags_to_list(number_tags(remove_inline_semantics(BeautifulSoup(commit_html, "html.parser"))))
+docx_current_version_list = tags_to_list(number_tags(remove_inline_semantics(copy.copy(bs4_docx_current_version_soup))))
 
-opcodes = difflib.SequenceMatcher(None, tags_to_list(remove_inline_semantics(BeautifulSoup(commit_html, "html.parser"))), tags_to_list(remove_inline_semantics(BeautifulSoup(docx_current_version_html, "html.parser")))).get_opcodes()
-redline = number_tags(remove_inline_semantics(BeautifulSoup(commit_html, "html.parser")))
+bs4_commit_soup = BeautifulSoup(commit_html, "html.parser")
+commit_list = tags_to_list(number_tags(remove_inline_semantics(copy.copy(bs4_commit_soup))))
+
+opcodes = difflib.SequenceMatcher(None, tags_to_list(remove_inline_semantics(copy.copy(bs4_commit_soup))), tags_to_list(remove_inline_semantics(copy.copy(bs4_docx_current_version_soup)))).get_opcodes()
+redline = number_tags(remove_inline_semantics(copy.copy(bs4_commit_soup)))
 
 def delete_tag(html, old_changed_strings):
     old_data_numbers = get_data_number(old_changed_strings)

--- a/diff.py
+++ b/diff.py
@@ -88,6 +88,12 @@ def get_data_number(tag_list):
                 data_number.add(parsed_tag.get('data-number'))
     return data_number
 
+def wrap_html(html):
+    soup = html
+    div = soup.new_tag("div", **{"class": "center"})
+    soup.wrap(div)
+    return div
+
 docx_current_version_list = tags_to_list(number_tags(remove_inline_semantics(docx_current_version_html)))
 
 commit_list = tags_to_list(number_tags(remove_inline_semantics(commit_html)))

--- a/diff.py
+++ b/diff.py
@@ -89,7 +89,7 @@ def get_data_number(tag_list):
     return data_number
 
 def wrap_html(html):
-    return f"<!DOCTYPE html><html><head><meta charset='UTF-8'>{styles}</head><body><div class='center'><div class='document'>{html}</div></div></body></html>"
+    return f"<!DOCTYPE html><html><head><meta charset='UTF-8'>{styles}</head><body><div class='center'><div>{html}</div></div></body></html>"
 
 bs4_docx_current_version_soup = BeautifulSoup(docx_current_version_html, "html.parser")
 

--- a/diff.py
+++ b/diff.py
@@ -91,15 +91,12 @@ def get_data_number(tag_list):
 def wrap_html(html):
     return f"<!DOCTYPE html><html><head><meta charset='UTF-8'>{styles}</head><body><div class='center'><div>{html}</div></div></body></html>"
 
-bs4_docx_current_version_soup = BeautifulSoup(docx_current_version_html, "html.parser")
+docx_current_version_list = tags_to_list(number_tags(remove_inline_semantics(BeautifulSoup(docx_current_version_html, "html.parser"))))
 
-docx_current_version_list = tags_to_list(number_tags(remove_inline_semantics(bs4_docx_current_version_soup)))
-
-bs4_commit_soup = BeautifulSoup(commit_html, "html.parser")
-commit_list = tags_to_list(number_tags(remove_inline_semantics(bs4_commit_soup)))
+commit_list = tags_to_list(number_tags(remove_inline_semantics(BeautifulSoup(commit_html, "html.parser"))))
 
 opcodes = difflib.SequenceMatcher(None, tags_to_list(remove_inline_semantics(BeautifulSoup(commit_html, "html.parser"))), tags_to_list(remove_inline_semantics(BeautifulSoup(docx_current_version_html, "html.parser")))).get_opcodes()
-redline = number_tags(remove_inline_semantics(bs4_commit_soup))
+redline = number_tags(remove_inline_semantics(BeautifulSoup(commit_html, "html.parser")))
 
 def delete_tag(html, old_changed_strings):
     old_data_numbers = get_data_number(old_changed_strings)

--- a/diff.py
+++ b/diff.py
@@ -89,7 +89,7 @@ def get_data_number(tag_list):
     return data_number
 
 def wrap_html(html):
-    return f"<!DOCTYPE html><html><head><meta charset='UTF-8'>{styles}</head><body><div class='center'>{html}</div></body></html>"
+    return f"<!DOCTYPE html><html><head><meta charset='UTF-8'>{styles}</head><body><div class='center'><div>{html}</div></div></body></html>"
 
 bs4_docx_current_version_soup = BeautifulSoup(docx_current_version_html, "html.parser")
 

--- a/diff.py
+++ b/diff.py
@@ -95,10 +95,10 @@ def wrap_html(html):
     return div
 bs4_docx_current_version_soup = BeautifulSoup(docx_current_version_html, "html.parser")
 
-docx_current_version_list = tags_to_list(number_tags(remove_inline_semantics(docx_current_version_html)))
+docx_current_version_list = tags_to_list(number_tags(remove_inline_semantics(bs4_docx_current_version_soup)))
 
 bs4_commit_soup = BeautifulSoup(commit_html, "html.parser")
-commit_list = tags_to_list(number_tags(remove_inline_semantics(commit_html)))
+commit_list = tags_to_list(number_tags(remove_inline_semantics(bs4_commit_soup)))
 
 opcodes = difflib.SequenceMatcher(None, tags_to_list(remove_inline_semantics(bs4_commit_soup)), tags_to_list(remove_inline_semantics(bs4_docx_current_version_soup))).get_opcodes()
 redline = number_tags(remove_inline_semantics(bs4_commit_soup))

--- a/diff.py
+++ b/diff.py
@@ -89,11 +89,7 @@ def get_data_number(tag_list):
     return data_number
 
 def wrap_html(html):
-    soup = html
-    div = soup.new_tag("div", **{"class": "center"})
-    soup.wrap(div)
-    return div
-bs4_docx_current_version_soup = BeautifulSoup(docx_current_version_html, "html.parser")
+    return f"<!DOCTYPE html><html><head><meta charset='UTF-8'>{styles}</head><body><div class='center'>{html}</div></body></html>"
 
 docx_current_version_list = tags_to_list(number_tags(remove_inline_semantics(bs4_docx_current_version_soup)))
 
@@ -180,4 +176,4 @@ for opcode in reversed(opcodes):
     if tag =="delete":
         redline = delete_tag(redline, old_changed_strings)
 with open("redline.html", "w", encoding="utf-8", newline="\n") as f:
-    f.write(f"{styles}\n{str(strip_number_attribute(redline))}")
+    f.write(f"{wrap_html(str(strip_number_attribute(redline)))}")


### PR DESCRIPTION
# Center HTML in Redline.html #36 

This PR focuses on centering the created HTML when diff a file; In Redline.html. 

##  Defaul_CSS_Styles.py

- Create new class `center`:

```CSS
.center {
display: flex;
justify-content: center;
}

## Diff.py

- Create Wrap_HTML(HTML) function to add styles to HTML and wrap in 2 divs; The outer with with class `center`.

- Create `commit_list` and `docx_current_version_list` with Bs4 object.

## Type of Change

- [ ] Feature