### PR TITLE
Docs/Warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A lightweight distributed version control system designed to help legal professionals easily view and understand different versions of .docx files currently. ( .pdf files planned)
 
 ## ⚠️ Please Read
+- **THEIR IS CURRENTLY NO WAY TO MIGRATE FROM VERSION TO VERSION BETWEEN PULL REQUESTS**
 - Build Status: Pre-Alpha
 - License: GPLv3
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A lightweight distributed version control system designed to help legal professionals easily view and understand different versions of .docx files currently. ( .pdf files planned)
 
 ## ⚠️ Please Read
-- **THEIR IS CURRENTLY NO WAY TO MIGRATE FROM VERSION TO VERSION BETWEEN PULL REQUESTS**
+- **THERE IS CURRENTLY NO WAY TO MIGRATE FROM VERSION TO VERSION BETWEEN PULL REQUESTS**
 - Build Status: Pre-Alpha
 - License: GPLv3
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A lightweight distributed version control system designed to help legal professionals easily view and understand different versions of .docx files currently. ( .pdf files planned)
 
 ## ⚠️ Please Read
-- **THERE IS CURRENTLY NO WAY TO MIGRATE FROM VERSION TO VERSION BETWEEN PULL REQUESTS**
+- **Repositories or clones created with older SCCS versions cannot currently be migrated to newer SCCS versions; please re-clone the repository or re-initialize SCCS instead.**
 - Build Status: Pre-Alpha
 - License: GPLv3
 


### PR DESCRIPTION
# Warn users that there is no migration protocol for older clones. 

This PR adds a warning message to the README stating that there is no migration protocol for older clones. 

## README.md

Warn users that there is no migration protocol for older clones. 

## Type of Change

- [ ] Documentation