### PR TITLE
Feat: Store commits centrally retrieve

### DIFF
--- a/commit.py
+++ b/commit.py
@@ -62,15 +62,15 @@ with open(history_path, "r", encoding="utf-8", newline="\n") as history_file:
 sha_hash = hashlib.sha256(f'{timestamp}/{commit_message}/{name}/{email}/{parent_hash}'.encode()).hexdigest()
 
 # Write .txt file
-with open(os.path.join(directory_path, ".sccs", "data-commits", "txt-commits", f"{sha_hash}.txt"), "w", encoding="utf-8", newline="\n") as f:
+with open(os.path.join(directory_path, ".sccs", "objects", "txt", f"{hashed_file}.txt"), "w", encoding="utf-8", newline="\n") as f:
     f.write(commit)
 
-shutil.copy2(os.path.join(directory_path, Path(path).name) , os.path.join(directory_path, ".sccs", "data-commits", "docx-commits", f"{sha_hash}.docx"))
+shutil.copy2(os.path.join(directory_path, Path(path).name) , os.path.join(directory_path, ".sccs", "objects", "docx", f"{hashed_file}.docx"))
 
-with open(os.path.join(directory_path, ".sccs", "data-commits", "html-commits", f"{sha_hash}.html"), "w", encoding="utf-8", newline="\n") as f:
+with open(os.path.join(directory_path, ".sccs", "objects", "html", f"{hashed_file}.html"), "w", encoding="utf-8", newline="\n") as f:
     f.write(styles + html)
 
-with open(os.path.join(directory_path, ".sccs", "view-commits", "html-commits", f"{sha_hash}.html"), "w", encoding="utf-8", newline="\n") as f:
+with open(os.path.join(directory_path, ".sccs", "objects", "view_html", f"{hashed_file}.html"), "w", encoding="utf-8", newline="\n") as f:
     f.write(wrap_html(html))    
 
 # Update history

--- a/init.py
+++ b/init.py
@@ -65,26 +65,25 @@ sha_hash = hashlib.sha256(f'{timestamp}/initial_version/{name}/{email}'.encode()
 os.makedirs(directory_path, exist_ok=True)
 shutil.move(path, directory_path)
 os.makedirs(os.path.join(directory_path, ".sccs"), exist_ok=True)
-os.makedirs(os.path.join(directory_path, ".sccs", "data-commits"), exist_ok=True)
-os.makedirs(os.path.join(directory_path, ".sccs", "data-commits", "txt-commits"), exist_ok=True)
-os.makedirs(os.path.join(directory_path, ".sccs", "data-commits", "docx-commits"), exist_ok=True)
-os.makedirs(os.path.join(directory_path, ".sccs", "data-commits", "html-commits"), exist_ok=True)
-os.makedirs(os.path.join(directory_path, ".sccs", "view-commits"), exist_ok=True)
-os.makedirs(os.path.join(directory_path, ".sccs", "view-commits", "html-commits"), exist_ok=True)
+os.makedirs(os.path.join(directory_path, ".sccs", "objects"), exist_ok=True)
+os.makedirs(os.path.join(directory_path, ".sccs", "objects", "txt"), exist_ok=True)
+os.makedirs(os.path.join(directory_path, ".sccs", "objects", "docx"), exist_ok=True)
+os.makedirs(os.path.join(directory_path, ".sccs", "objects", "html"), exist_ok=True)
+os.makedirs(os.path.join(directory_path, ".sccs", "objects", "view_html"), exist_ok=True)
 os.makedirs(os.path.join(directory_path, ".sccs", "history"), exist_ok=True)
 os.makedirs(os.path.join(directory_path, ".sccs", "commit_messages"), exist_ok=True)
 os.makedirs(os.path.join(directory_path, ".sccs", "config"), exist_ok=True)
 os.makedirs(os.path.join(directory_path, ".sccs", "commit_file_hash"), exist_ok=True)
 # Add info to the directories, JSON
-with open(os.path.join(directory_path, ".sccs", "data-commits", "txt-commits", f"{sha_hash}.txt"), "w", encoding="utf-8", newline="\n") as f:
+with open(os.path.join(directory_path, ".sccs", "objects", "txt", f"{hashed_file}.txt"), "w", encoding="utf-8", newline="\n") as f:
     f.write(docx_to_txt)
 
-shutil.copy2(os.path.join(directory_path, Path(path).name), os.path.join(directory_path, ".sccs", "data-commits", "docx-commits", f"{sha_hash}.docx"))
+shutil.copy2(os.path.join(directory_path, Path(path).name), os.path.join(directory_path, ".sccs", "objects", "docx", f"{hashed_file}.docx"))
 
-with open(os.path.join(directory_path, ".sccs", "data-commits", "html-commits", f"{sha_hash}.html"), "w", encoding="utf-8", newline="\n") as f:
+with open(os.path.join(directory_path, ".sccs", "objects", "html", f"{hashed_file}.html"), "w", encoding="utf-8", newline="\n") as f:
     f.write(styles + html)
 
-with open(os.path.join(directory_path, ".sccs", "view-commits", "html-commits", f"{sha_hash}.html"), "w", encoding="utf-8", newline="\n") as f:
+with open(os.path.join(directory_path, ".sccs", "objects", "view_html", f"{hashed_file}.html"), "w", encoding="utf-8", newline="\n") as f:
     f.write(wrap_html(html))
 
 history_data = {

--- a/sccs_layout_check.py
+++ b/sccs_layout_check.py
@@ -32,28 +32,24 @@ def check_sccs():
         print("Commit messages JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
         sys.exit(1)
 
-    if not Path(os.path.join(sccs_dir, "data-commits")).is_dir():
-        print("Commits data directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    if not Path(os.path.join(sccs_dir, "objects")).is_dir():
+        print("Objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
         sys.exit(1)
 
-    if not Path(os.path.join(sccs_dir, "data-commits", "txt-commits")).is_dir():
-        print("Text commits directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    if not Path(os.path.join(sccs_dir, "objects", "txt")).is_dir():
+        print("Text objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
         sys.exit(1)
 
-    if not Path(os.path.join(sccs_dir, "data-commits", "docx-commits")).is_dir():
-        print("Docx commits directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    if not Path(os.path.join(sccs_dir, "objects", "docx")).is_dir():
+        print("Docx objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
         sys.exit(1)
 
-    if not Path(os.path.join(sccs_dir, "data-commits", "html-commits")).is_dir():
-        print("HTML commits directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    if not Path(os.path.join(sccs_dir, "objects", "html")).is_dir():
+        print("HTML objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
         sys.exit(1)
 
-    if not Path(os.path.join(sccs_dir, "view-commits")).is_dir():
-        print("View commits directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
-        sys.exit(1)
-
-    if not Path(os.path.join(sccs_dir, "view-commits", "html-commits")).is_dir():
-        print("View HTML commits directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    if not Path(os.path.join(sccs_dir, "objects", "view_html")).is_dir():
+        print("View HTML objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
         sys.exit(1)
 
     if not Path(os.path.join(sccs_dir, "config")).is_dir():


### PR DESCRIPTION
# What does this PR do? Refactor SCCS to use deduplicated object storage

This PR implements a more Git-like object storage model for SCCS. It replaces the `data-commits` and `view-commits` directories with a unified `.sccs/objects` folder. File objects (.txt, .docx, .html) are now saved using the actual file's hash rather than the commit's hash. Because `commit_file_hash.json` already maps each commit hash to the correct file hash, this architecture naturally deduplicates storage—meaning identical file states across different commits will correctly point to a single stored object.

## `init.py`

- Removed the initialization of `data-commits` and `view-commits` directory paths.
- Added directory creation for the new `.sccs/objects` folder and its respective subdirectories (`txt`, `docx`, `html`, `view_html`).
- Updated the file creation step to save the initial objects using the file's hash (`hashed_file`).

## `commit.py`

- Updated the paths for writing objects to point to the new `.sccs/objects` structure.
- Changed the file output naming logic to use `hashed_file` instead of `sha_hash` so that commits share underlying file objects if the contents haven't changed.

## `sccs_layout_check.py`

- Replaced validation checks for the old `data-commits` and `view-commits` directories.
- Added path validation for the new `objects`, `objects/txt`, `objects/docx`, `objects/html`, and `objects/view_html` directories to ensure `check_sccs()` functions correctly on the new layout.

## Type of Change

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
