### PR TITLE
Feat/delete text commits

### DIFF
--- a/commit.py
+++ b/commit.py
@@ -12,6 +12,16 @@ from sccs_layout_check import check_sccs, path, directory_path, wrap_html
 
 check_sccs()
 
+try:
+    with open(path, "rb") as f:
+        hasher = hashlib.sha256()
+        for chunk in iter(lambda: f.read(65536), b""):
+            hasher.update(chunk)
+        hashed_file = hasher.hexdigest()
+except Exception as e:
+    print(f"Error processing .docx file: {e}")
+    sys.exit(1)
+
 try: 
     with open(path, "rb") as f:
         result = mammoth.convert_to_html(f)
@@ -110,7 +120,7 @@ except (json.JSONDecodeError, KeyError, TypeError, OSError) as e:
     print("Commit file hash is missing or corrupted. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-commit_file_hash[f"{sha_hash}"] = f"{sha_hash}"
+commit_file_hash[f"{sha_hash}"] = f"{hashed_file}"
 
 with open(commit_file_hash_path, "w", encoding="utf-8", newline="\n") as f:
     json.dump(commit_file_hash, f, indent=4)

--- a/commit.py
+++ b/commit.py
@@ -120,7 +120,7 @@ except (json.JSONDecodeError, KeyError, TypeError, OSError) as e:
     print("Commit file hash is missing or corrupted. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-commit_file_hash[f"{sha_hash}"] = f"{hashed_file}"
+commit_file_hash[f"{sha_hash}"] = hashed_file
 
 with open(commit_file_hash_path, "w", encoding="utf-8", newline="\n") as f:
     json.dump(commit_file_hash, f, indent=4)

--- a/commit.py
+++ b/commit.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 import shutil
 import sys
-import docx2txt 
 import hashlib
 from datetime import datetime
 import json
@@ -12,17 +11,6 @@ from sccs_layout_check import check_sccs, path, directory_path, wrap_html
 
 
 check_sccs()
-
-try: 
-    commit = docx2txt.process(path)
-    with open(path, "rb") as f:
-        hasher = hashlib.sha256()
-        for chunk in iter(lambda: f.read(65536), b""):
-            hasher.update(chunk)
-        hashed_file = hasher.hexdigest()
-except Exception as e:
-    print(f"Error processing .docx file: {e}")
-    sys.exit(1)
 
 try: 
     with open(path, "rb") as f:
@@ -61,16 +49,12 @@ with open(history_path, "r", encoding="utf-8", newline="\n") as history_file:
 # Generate commit hash from time, message, name, email, and previous commit hash
 sha_hash = hashlib.sha256(f'{timestamp}/{commit_message}/{name}/{email}/{parent_hash}'.encode()).hexdigest()
 
-# Write .txt file
-with open(os.path.join(directory_path, ".sccs", "objects", "txt", f"{hashed_file}.txt"), "w", encoding="utf-8", newline="\n") as f:
-    f.write(commit)
+shutil.copy2(os.path.join(directory_path, Path(path).name) , os.path.join(directory_path, ".sccs", "objects", "docx", f"{sha_hash}.docx"))
 
-shutil.copy2(os.path.join(directory_path, Path(path).name) , os.path.join(directory_path, ".sccs", "objects", "docx", f"{hashed_file}.docx"))
-
-with open(os.path.join(directory_path, ".sccs", "objects", "html", f"{hashed_file}.html"), "w", encoding="utf-8", newline="\n") as f:
+with open(os.path.join(directory_path, ".sccs", "objects", "html", f"{sha_hash}.html"), "w", encoding="utf-8", newline="\n") as f:
     f.write(styles + html)
 
-with open(os.path.join(directory_path, ".sccs", "objects", "view_html", f"{hashed_file}.html"), "w", encoding="utf-8", newline="\n") as f:
+with open(os.path.join(directory_path, ".sccs", "objects", "view_html", f"{sha_hash}.html"), "w", encoding="utf-8", newline="\n") as f:
     f.write(wrap_html(html))    
 
 # Update history
@@ -126,7 +110,7 @@ except (json.JSONDecodeError, KeyError, TypeError, OSError) as e:
     print("Commit file hash is missing or corrupted. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     sys.exit(1)
 
-commit_file_hash[f"{sha_hash}"] = hashed_file
+commit_file_hash[f"{sha_hash}"] = f"{sha_hash}"
 
 with open(commit_file_hash_path, "w", encoding="utf-8", newline="\n") as f:
     json.dump(commit_file_hash, f, indent=4)

--- a/help.py
+++ b/help.py
@@ -4,7 +4,7 @@ print("  init    - Initialize a new SCCS repository")
 print("  commit  - Commit changes to a repository")
 print("  open    - Restore a previous commit and overwrite the current changes")
 print("  log     - Show commit history")
-print("  diff    - Compare the current .docx (as text) with a specified commit .html file")
+print("  diff    - Compare the current .docx converted to HTML with a specified commit .html file")
 print("  status  - Show the status of a repository")
 print("  help    - Show this help message")
 

--- a/help.py
+++ b/help.py
@@ -4,7 +4,7 @@ print("  init    - Initialize a new SCCS repository")
 print("  commit  - Commit changes to a repository")
 print("  open    - Restore a previous commit and overwrite the current changes")
 print("  log     - Show commit history")
-print("  diff    - Compare the current .docx (as text) with a specified commit .txt file")
+print("  diff    - Compare the current .docx (as text) with a specified commit .html file")
 print("  status  - Show the status of a repository")
 print("  help    - Show this help message")
 

--- a/init.py
+++ b/init.py
@@ -2,7 +2,6 @@ import os
 import shutil
 from pathlib import Path
 import sys
-import docx2txt 
 import hashlib
 from datetime import datetime
 import json
@@ -26,16 +25,6 @@ if Path(os.path.join(directory_path, ".sccs")).is_dir():
 
 # Check if the path ends with .docx and exists
 elif path and Path(path).suffix.lower() == ".docx" and Path(path).is_file():
-    try:
-        docx_to_txt = docx2txt.process(path)
-        with open(path, "rb") as f:
-            hasher = hashlib.sha256()
-            for chunk in iter(lambda: f.read(65536), b""):
-                hasher.update(chunk)
-            hashed_file = hasher.hexdigest()
-    except Exception as e:
-        print(f"Error processing .docx file: {e}")
-        sys.exit(1)
     
     try: 
         with open(path, "rb") as f:
@@ -66,7 +55,6 @@ os.makedirs(directory_path, exist_ok=True)
 shutil.move(path, directory_path)
 os.makedirs(os.path.join(directory_path, ".sccs"), exist_ok=True)
 os.makedirs(os.path.join(directory_path, ".sccs", "objects"), exist_ok=True)
-os.makedirs(os.path.join(directory_path, ".sccs", "objects", "txt"), exist_ok=True)
 os.makedirs(os.path.join(directory_path, ".sccs", "objects", "docx"), exist_ok=True)
 os.makedirs(os.path.join(directory_path, ".sccs", "objects", "html"), exist_ok=True)
 os.makedirs(os.path.join(directory_path, ".sccs", "objects", "view_html"), exist_ok=True)
@@ -75,15 +63,13 @@ os.makedirs(os.path.join(directory_path, ".sccs", "commit_messages"), exist_ok=T
 os.makedirs(os.path.join(directory_path, ".sccs", "config"), exist_ok=True)
 os.makedirs(os.path.join(directory_path, ".sccs", "commit_file_hash"), exist_ok=True)
 # Add info to the directories, JSON
-with open(os.path.join(directory_path, ".sccs", "objects", "txt", f"{hashed_file}.txt"), "w", encoding="utf-8", newline="\n") as f:
-    f.write(docx_to_txt)
 
-shutil.copy2(os.path.join(directory_path, Path(path).name), os.path.join(directory_path, ".sccs", "objects", "docx", f"{hashed_file}.docx"))
+shutil.copy2(os.path.join(directory_path, Path(path).name), os.path.join(directory_path, ".sccs", "objects", "docx", f"{sha_hash}.docx"))
 
-with open(os.path.join(directory_path, ".sccs", "objects", "html", f"{hashed_file}.html"), "w", encoding="utf-8", newline="\n") as f:
+with open(os.path.join(directory_path, ".sccs", "objects", "html", f"{sha_hash}.html"), "w", encoding="utf-8", newline="\n") as f:
     f.write(styles + html)
 
-with open(os.path.join(directory_path, ".sccs", "objects", "view_html", f"{hashed_file}.html"), "w", encoding="utf-8", newline="\n") as f:
+with open(os.path.join(directory_path, ".sccs", "objects", "view_html", f"{sha_hash}.html"), "w", encoding="utf-8", newline="\n") as f:
     f.write(wrap_html(html))
 
 history_data = {
@@ -125,7 +111,7 @@ with open(os.path.join(directory_path, ".sccs", "config", "config.json"), "w", e
     json.dump(config_data, f, indent=4)
 
 commit_file_hash_data = {
-    f"{sha_hash}": f"{hashed_file}"
+    f"{sha_hash}": f"{sha_hash}"
 }
 
 with open (os.path.join(directory_path, ".sccs", "commit_file_hash", f"commit_file_hash.json"), "w", encoding="utf-8", newline="\n") as f:

--- a/init.py
+++ b/init.py
@@ -119,7 +119,7 @@ with open(os.path.join(directory_path, ".sccs", "config", "config.json"), "w", e
     json.dump(config_data, f, indent=4)
 
 commit_file_hash_data = {
-    f"{sha_hash}": f"{hashed_file}"
+    f"{sha_hash}": hashed_file
 }
 
 with open (os.path.join(directory_path, ".sccs", "commit_file_hash", f"commit_file_hash.json"), "w", encoding="utf-8", newline="\n") as f:

--- a/init.py
+++ b/init.py
@@ -25,7 +25,15 @@ if Path(os.path.join(directory_path, ".sccs")).is_dir():
 
 # Check if the path ends with .docx and exists
 elif path and Path(path).suffix.lower() == ".docx" and Path(path).is_file():
-    
+    try:
+        with open(path, "rb") as f:
+            hasher = hashlib.sha256()
+            for chunk in iter(lambda: f.read(65536), b""):
+                hasher.update(chunk)
+            hashed_file = hasher.hexdigest()
+    except Exception as e:
+        print(f"Error processing .docx file: {e}")
+        sys.exit(1)
     try: 
         with open(path, "rb") as f:
             result = mammoth.convert_to_html(f)
@@ -111,7 +119,7 @@ with open(os.path.join(directory_path, ".sccs", "config", "config.json"), "w", e
     json.dump(config_data, f, indent=4)
 
 commit_file_hash_data = {
-    f"{sha_hash}": f"{sha_hash}"
+    f"{sha_hash}": f"{hashed_file}"
 }
 
 with open (os.path.join(directory_path, ".sccs", "commit_file_hash", f"commit_file_hash.json"), "w", encoding="utf-8", newline="\n") as f:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 beautifulsoup4==4.14.3
 bs4==0.0.2
 cobble==0.1.4
-docx2txt==0.9
 lxml==6.0.4
 mammoth==1.12.0
 python-docx==0.8.11

--- a/sccs_layout_check.py
+++ b/sccs_layout_check.py
@@ -36,10 +36,6 @@ def check_sccs():
         print("Objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
         sys.exit(1)
 
-    if not Path(os.path.join(sccs_dir, "objects", "txt")).is_dir():
-        print("Text objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
-        sys.exit(1)
-
     if not Path(os.path.join(sccs_dir, "objects", "docx")).is_dir():
         print("Docx objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
         sys.exit(1)


### PR DESCRIPTION
# Remove `.txt` Commits #42 

This PR focuses on removing the creation of `.txt` commits during initialization and after commits, as `.html` commits are used for diffing, making `.txt` commits obsolete.

## Commit.py

- Remove `docx2txt` import.
- Remove `docx2txt.process` conversion.
- Remove write of `.txt` file.
- Change all instances of `hashed_file` to `sha_hash`. 

## Help.py

- Change `.txt` to `.html`

## Init.py

- Remove `docx2txt` import.
- Remove `docx2txt.process` conversion.
- Remove write of `.txt` file.
- Change all instances of `hashed_file` to `sha_hash`. 

## Requirements.txt

- Remove docx2txt from dependency list

## SCCS_layout_check.py.

- Remove check for txt files directory in `.sccs/objects`.

## Type of Change

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Refactor

      
