### PR TITLE
Feat/switch branches command

### DIFF
--- a/branch.py
+++ b/branch.py
@@ -64,6 +64,7 @@ if subcommand == 'create':
         with open(current_branch_path, "w", encoding="utf-8", newline="\n") as current_branch_file:
             try:    
                 branch_data["branches"].append(sanitized_branch_name)
+                branch_data["current_branch"] = sanitized_branch_name
                 json.dump(branch_data, current_branch_file, indent=4)
             except Exception as e:
                 print(f"Error updating branch data: {e}")
@@ -73,7 +74,7 @@ if subcommand == 'create':
         print(f"Error creating branch '{sanitized_branch_name}': {e}")
         sys.exit(1)
 
-    print(f"Branch '{sanitized_branch_name}' was created from branch '{current_branch}'.")
+    print(f"Branch '{sanitized_branch_name}' was created from branch '{current_branch}', and is now the current branch.")
          
 
 if subcommand == 'delete':

--- a/branch.py
+++ b/branch.py
@@ -1,4 +1,3 @@
-import re
 import sys
 import os
 import json

--- a/branch.py
+++ b/branch.py
@@ -3,12 +3,9 @@ import sys
 import os
 import json
 import shutil
-from sccs_layout_check import check_sccs, directory_path
+from sccs_layout_check import check_sccs, directory_path, sanitize_dirname
 
 check_sccs()
-
-def sanitize_dirname(name):
-    return re.sub(r'[\\/:*?"<>|]', '-', name).strip('. ')
 
 current_branch_path = os.path.join(directory_path, ".sccs", "current_branch", "current_branch.json")
 try:

--- a/sccs
+++ b/sccs
@@ -35,7 +35,7 @@ elif command == "switch":
 
 else: 
     print(f"Unknown command: {command}")
-    print("Invalid command. Please use 'init', 'commit', 'open', 'log', 'diff', 'status', 'help', 'branch' or 'switch', along with required arguments.")
+    print("Invalid command. Please use 'init', 'commit', 'open', 'log', 'diff', 'status', 'help', 'branch', or 'switch', along with required arguments.")
     print("For help, use the 'sccs help' command.")
     sys.exit(1)
 

--- a/sccs
+++ b/sccs
@@ -30,10 +30,13 @@ elif command == "help":
 elif command == "branch":
     sys.exit(subprocess.run([sys.executable, os.path.join(script_directory, "branch.py")] + sys.argv[1:]).returncode)
 
+elif command == "switch":
+    sys.exit(subprocess.run([sys.executable, os.path.join(script_directory, "switch.py")] + sys.argv[1:]).returncode)
+
 else: 
     print(f"Unknown command: {command}")
-    print("Invalid command. Please use 'init', 'commit', 'open', 'log', 'diff', 'status', 'help', or 'branch', along with required arguments.")
+    print("Invalid command. Please use 'init', 'commit', 'open', 'log', 'diff', 'status', 'help', 'branch' or 'switch', along with required arguments.")
     print("For help, use the 'sccs help' command.")
     sys.exit(1)
 
-# If on MacOS / Linux, move this file, commit.py, init.py, open.py, log.py, diff.py, status.py, help.py, and branch.py to /usr/local/bin and make it executable with `chmod +x /usr/local/bin/sccs`
+# If on MacOS / Linux, move this file, commit.py, init.py, open.py, log.py, diff.py, status.py, help.py, branch.py , and switch.py to /usr/local/bin and make it executable with `chmod +x /usr/local/bin/sccs`

--- a/sccs.bat
+++ b/sccs.bat
@@ -51,7 +51,13 @@ if "%command%"=="branch" (
     exit /b !errorlevel!
 )
 
+if "%command%"=="switch" (
+    set "script_directory=%~dp0"
+    python "%script_directory%switch.py" %*
+    exit /b !errorlevel!
+)
+
 echo Unknown command: %command%
-echo Invalid command. Please use "init", "commit", "open", "log", "status", "diff", "help", or "branch", along with required arguments
+echo Invalid command. Please use "init", "commit", "open", "log", "status", "diff", "help", "branch", or "switch", along with required arguments
 echo For help, use the 'sccs help' command
 exit /b 1

--- a/sccs_layout_check.py
+++ b/sccs_layout_check.py
@@ -1,6 +1,7 @@
 import json
 import os
 from pathlib import Path
+import re
 import sys
 from default_css_styles import styles
 
@@ -9,6 +10,9 @@ directory_path = os.getcwd()
 path = os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx")
 
 sccs_dir = os.path.join(directory_path, ".sccs")
+
+def sanitize_dirname(name):
+    return re.sub(r'[\\/:*?"<>|]', '-', name).strip('. ')
 
 def check_sccs():
 

--- a/switch.py
+++ b/switch.py
@@ -36,4 +36,7 @@ if confirmation.lower() == "y": confirmation = True
 else:  confirmation = False
    
 if confirmation:
-    shutil.copy2(os.path.join(directory_path, ".sccs", "objects", "docx", f"{latest_commit_on_branch}.docx"), os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx"))
+    try:
+        shutil.copy2(os.path.join(directory_path, ".sccs", "objects", "docx", f"{latest_commit_on_branch}.docx"), os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx"))
+    except Exception as e:
+        print(f"Error switching to branch '{branch_to_switch}': {e}")

--- a/switch.py
+++ b/switch.py
@@ -29,27 +29,17 @@ except Exception as e:
     sys.exit(1)
 
 try:
-    latest_commit_on_branch = commit_history["history"]["latest_commit"]
+    latest_commit_on_branch_to_switch = commit_history["history"]["latest_commit"]
 
 except KeyError as e:
     print(f"Error: Missing key {e} in commit history for branch '{branch_to_switch}'.")
     sys.exit(1)
 
-if not os.path.isfile(os.path.join(directory_path, ".sccs", "objects", "docx", f"{latest_commit_on_branch}.docx")):
-    print(f"Error: Commit object '{latest_commit_on_branch}' not found.")
+if not os.path.isfile(os.path.join(directory_path, ".sccs", "objects", "docx", f"{latest_commit_on_branch_to_switch}.docx")):
+    print(f"Error: Commit object '{latest_commit_on_branch_to_switch}' not found.")
     sys.exit(1)
 
 try:
-    with open(path, "rb") as f:
-        hasher = hashlib.sha256()
-        for chunk in iter(lambda: f.read(65536), b""):
-            hasher.update(chunk)
-        hashed_file = hasher.hexdigest()
-except Exception as e:
-    print(f"Error processing .docx file: {e}")
-    sys.exit(1)
-    
-try: 
     with open(os.path.join(directory_path, ".sccs", "current_branch", "current_branch.json"), "r", encoding="utf-8", newline="\n") as f:
         try:
             current_branch = json.load(f)
@@ -59,29 +49,6 @@ try:
 except Exception as e:
     print(f"Error accessing current branch information: {e}")
     sys.exit(1)
-
-try:
-    with open(os.path.join(directory_path, ".sccs", "branches", current_branch["current_branch"], "commit_file_hash", "commit_file_hash.json"), "r", encoding="utf-8", newline="\n") as f:
-        try:
-            commit_file_hash = json.load(f).get(latest_commit_on_branch)
-        except Exception as e:    
-            print(f"Error reading commit file hash information: {e}")
-            sys.exit(1)
-except Exception as e:
-    print(f"Error accessing commit file hash information: {e}")
-    sys.exit(1)
-
-if not commit_file_hash == hashed_file:
-    print(f"Error: Cannot switch to branch '{branch_to_switch}' because the current file has uncommitted changes, or the byte content does not match the latest commit. Please commit your changes before switching branches.")
-    sys.exit(1)
-
-try:
-    shutil.copy2(os.path.join(directory_path, ".sccs", "objects", "docx", f"{latest_commit_on_branch}.docx"), os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx"))
-except Exception as e:
-    print(f"Error switching to branch '{branch_to_switch}': {e}")
-    sys.exit(1)
-
-
 
 current_branch["current_branch"] = branch_to_switch
 
@@ -94,6 +61,13 @@ try:
             sys.exit(1)
 except Exception as e:
     print(f"Error updating current branch information: {e}")
+    sys.exit(1)
+
+try:
+    shutil.copy2(os.path.join(directory_path, ".sccs", "objects", "docx", f"{latest_commit_on_branch_to_switch}.docx"), os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx"))
+except Exception as e:
+    print(f"Error switching to branch '{branch_to_switch}': {e}")
+    
     sys.exit(1)
 
 print(f"Successfully switched to branch '{branch_to_switch}'.")

--- a/switch.py
+++ b/switch.py
@@ -8,6 +8,55 @@ check_sccs()
 
 branch_to_switch = sys.argv[2] if len(sys.argv) > 2 else None
 
+try:
+    with open(os.path.join(directory_path, ".sccs", "current_branch", "current_branch.json"), "r", encoding="utf-8", newline="\n") as f:
+        try:
+            branch = json.load(f).get("current_branch")
+        except Exception as e:
+            print(f"Error reading current branch information: {e}")
+            sys.exit(1)
+except Exception as e:
+    print(f"Error accessing current branch information: {e}")
+    sys.exit(1)
+
+try: 
+    with open(os.path.join(directory_path, ".sccs", "branches", branch, "history", "commit_history.json"), "r", encoding="utf-8", newline="\n") as f:
+        try:
+            latest_commit = json.load(f).get("history")["latest_commit"]
+        except Exception as e:
+            print(f"Error reading commit history for branch '{branch}': {e}")
+            sys.exit(1)
+except Exception as e:
+    print(f"Error accessing commit history for branch '{branch}': {e}")
+    sys.exit(1)
+
+try:
+    with open(os.path.join(directory_path, ".sccs", "branches", branch, "commit_file_hash", "commit_file_hash.json"), "r", encoding="utf-8", newline="\n") as f:
+        try:
+            latest_commit_file_hash = json.load(f).get(latest_commit)
+        except Exception as e:
+            print(f"Error reading commit file hash for branch '{branch}': {e}")
+            sys.exit(1)
+except Exception as e:
+    print(f"Error accessing commit file hash for branch '{branch}': {e}")
+    sys.exit(1)
+
+try:
+    with open(path, "rb") as f:
+        hasher = hashlib.sha256()
+        for chunk in iter(lambda: f.read(65536), b""):
+            hasher.update(chunk)
+        hashed_file = hasher.hexdigest()
+except Exception as e:
+    print(f"Error processing .docx file: {e}")
+    sys.exit(1)
+
+if not hashed_file == latest_commit_file_hash:
+    print(hashed_file)
+    print(latest_commit_file_hash)
+    print(f"Error: The current file has uncommitted changes on the current branch '{branch}'. Please commit your changes before switching branches.." )
+    sys.exit(1)
+
 if branch_to_switch:
     branch_to_switch = sanitize_dirname(branch_to_switch)
 
@@ -67,7 +116,7 @@ try:
     shutil.copy2(os.path.join(directory_path, ".sccs", "objects", "docx", f"{latest_commit_on_branch_to_switch}.docx"), os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx"))
 except Exception as e:
     print(f"Error switching to branch '{branch_to_switch}': {e}")
-    
+
     sys.exit(1)
 
 print(f"Successfully switched to branch '{branch_to_switch}'.")

--- a/switch.py
+++ b/switch.py
@@ -1,4 +1,4 @@
-from sccs_layout_check import check_sccs, directory_path, path
+from sccs_layout_check import check_sccs, directory_path
 import sys
 import os
 import json

--- a/switch.py
+++ b/switch.py
@@ -1,4 +1,5 @@
-from sccs_layout_check import check_sccs, directory_path, sanitize_dirname
+from sccs_layout_check import check_sccs, directory_path, sanitize_dirname, path
+import hashlib
 import sys
 import os
 import json
@@ -32,12 +33,17 @@ latest_commit_on_branch = commit_history["history"]["latest_commit"]
 if not os.path.isfile(os.path.join(directory_path, ".sccs", "objects", "docx", f"{latest_commit_on_branch}.docx")):
     print(f"Error: Commit object '{latest_commit_on_branch}' not found.")
     sys.exit(1)
-try:
-    shutil.copy2(os.path.join(directory_path, ".sccs", "objects", "docx", f"{latest_commit_on_branch}.docx"), os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx"))
-except Exception as e:
-    print(f"Error switching to branch '{branch_to_switch}': {e}")
-    sys.exit(1)
 
+try:
+    with open(path, "rb") as f:
+        hasher = hashlib.sha256()
+        for chunk in iter(lambda: f.read(65536), b""):
+            hasher.update(chunk)
+        hashed_file = hasher.hexdigest()
+except Exception as e:
+    print(f"Error processing .docx file: {e}")
+    sys.exit(1)
+    
 try: 
     with open(os.path.join(directory_path, ".sccs", "current_branch", "current_branch.json"), "r", encoding="utf-8", newline="\n") as f:
         try:
@@ -48,6 +54,29 @@ try:
 except Exception as e:
     print(f"Error accessing current branch information: {e}")
     sys.exit(1)
+
+try:
+    with open(os.path.join(directory_path, ".sccs", "branches", current_branch["current_branch"], "commit_file_hash", "commit_file_hash.json"), "r", encoding="utf-8", newline="\n") as f:
+        try:
+            commit_file_hash = json.load(f).get(latest_commit_on_branch)
+        except Exception as e:    
+            print(f"Error reading commit file hash information: {e}")
+            sys.exit(1)
+except Exception as e:
+    print(f"Error accessing commit file hash information: {e}")
+    sys.exit(1)
+
+if not commit_file_hash == hashed_file:
+    print(f"Error: Cannot switch to branch '{branch_to_switch}' because the current file has uncommitted changes, or the byte content does not match the latest commit. Please commit your changes before switching branches.")
+    sys.exit(1)
+
+try:
+    shutil.copy2(os.path.join(directory_path, ".sccs", "objects", "docx", f"{latest_commit_on_branch}.docx"), os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx"))
+except Exception as e:
+    print(f"Error switching to branch '{branch_to_switch}': {e}")
+    sys.exit(1)
+
+
 
 current_branch["current_branch"] = branch_to_switch
 

--- a/switch.py
+++ b/switch.py
@@ -28,7 +28,12 @@ except Exception as e:
     print(f"Error reading commit history for branch '{branch_to_switch}': {e}")
     sys.exit(1)
 
-latest_commit_on_branch = commit_history["history"]["latest_commit"]
+try:
+    latest_commit_on_branch = commit_history["history"]["latest_commit"]
+
+except KeyError as e:
+    print(f"Error: Missing key {e} in commit history for branch '{branch_to_switch}'.")
+    sys.exit(1)
 
 if not os.path.isfile(os.path.join(directory_path, ".sccs", "objects", "docx", f"{latest_commit_on_branch}.docx")):
     print(f"Error: Commit object '{latest_commit_on_branch}' not found.")
@@ -67,7 +72,8 @@ except Exception as e:
     sys.exit(1)
 
 if not commit_file_hash == hashed_file:
-    print(f"Error: Cannot switch to branch '{branch_to_switch}' because the current file has uncommitted changes, or the byte content does not match the latest commit. Please commit your changes before switching branches.")
+    print(f"Error: Cannot switch to branch '{branch_to_switch}' because the current file has uncommitted changes, or the byte content does not match the latest commit. Please commit your changes before switching branches.
+          ")
     sys.exit(1)
 
 try:

--- a/switch.py
+++ b/switch.py
@@ -27,7 +27,7 @@ except Exception as e:
     print(f"Error reading commit history for branch '{branch_to_switch}': {e}")
     sys.exit(1)
 
-latest_commit_on_branch = commit_history["history"]["commit_order"][f"{commit_history['history']['latest_commit_number']}"]
+latest_commit_on_branch = commit_history["history"]["latest_commit"]
 
 if not os.path.isfile(os.path.join(directory_path, ".sccs", "objects", "docx", f"{latest_commit_on_branch}.docx")):
     print(f"Error: Commit object '{latest_commit_on_branch}' not found.")

--- a/switch.py
+++ b/switch.py
@@ -29,18 +29,12 @@ latest_commit_on_branch = commit_history["history"]["commit_order"][f"{commit_hi
 if not os.path.isfile(os.path.join(directory_path, ".sccs", "objects", "docx", f"{latest_commit_on_branch}.docx")):
     print(f"Error: Commit object '{latest_commit_on_branch}' not found.")
     sys.exit(1)
+try:
+    shutil.copy2(os.path.join(directory_path, ".sccs", "objects", "docx", f"{latest_commit_on_branch}.docx"), os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx"))
+except Exception as e:
+    print(f"Error switching to branch '{branch_to_switch}': {e}")
+    sys.exit(1)
 
-confirmation = input(f"Are you sure you want to switch to branch '{branch_to_switch}'? This will overwrite all uncommitted changes (Y/N): ")
-
-if confirmation.lower() == "y": confirmation = True 
-else:  confirmation = False
-   
-if confirmation:
-    try:
-        shutil.copy2(os.path.join(directory_path, ".sccs", "objects", "docx", f"{latest_commit_on_branch}.docx"), os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx"))
-    except Exception as e:
-        print(f"Error switching to branch '{branch_to_switch}': {e}")
-        sys.exit(1)
 try: 
     with open(os.path.join(directory_path, ".sccs", "current_branch", "current_branch.json"), "r") as f:
         try:

--- a/switch.py
+++ b/switch.py
@@ -1,4 +1,4 @@
-from sccs_layout_check import check_sccs, directory_path
+from sccs_layout_check import check_sccs, directory_path, sanitize_dirname
 import sys
 import os
 import json
@@ -6,6 +6,9 @@ import shutil
 check_sccs()
 
 branch_to_switch = sys.argv[2] if len(sys.argv) > 2 else None
+
+if branch_to_switch:
+    branch_to_switch = sanitize_dirname(branch_to_switch)
 
 if not branch_to_switch:
     print("No branch specified. Please provide a branch name to switch to.")

--- a/switch.py
+++ b/switch.py
@@ -12,7 +12,7 @@ if not branch_to_switch:
     sys.exit(1)
 
 try:
-    with open(os.path.join(directory_path, ".sccs",  "branches", branch_to_switch, "history", "commit_history.json"), "r") as f:
+    with open(os.path.join(directory_path, ".sccs",  "branches", branch_to_switch, "history", "commit_history.json"), "r", encoding="utf-8", newline="\n") as f:
         try:
             commit_history = json.load(f)
             
@@ -36,7 +36,7 @@ except Exception as e:
     sys.exit(1)
 
 try: 
-    with open(os.path.join(directory_path, ".sccs", "current_branch", "current_branch.json"), "r") as f:
+    with open(os.path.join(directory_path, ".sccs", "current_branch", "current_branch.json"), "r", encoding="utf-8", newline="\n") as f:
         try:
             current_branch = json.load(f)
         except Exception as e:
@@ -49,9 +49,9 @@ except Exception as e:
 current_branch["current_branch"] = branch_to_switch
 
 try:
-    with open(os.path.join(directory_path, ".sccs", "current_branch", "current_branch.json"), "w") as f:
+    with open(os.path.join(directory_path, ".sccs", "current_branch", "current_branch.json"), "w", encoding="utf-8", newline="\n") as f:
         try:
-            json.dump(current_branch, f)
+            json.dump(current_branch, f, indent=4)
         except Exception as e:
             print(f"Error writing current branch information: {e}")
             sys.exit(1)

--- a/switch.py
+++ b/switch.py
@@ -1,0 +1,11 @@
+from sccs_layout_check import check_sccs, directory_path, path
+import sys
+
+check_sccs()
+
+branch_to_switch = sys.argv[2] if len(sys.argv) > 2 else None
+
+if not branch_to_switch:
+    print("No branch specified. Please provide a branch name to switch to.")
+    sys.exit(1)
+

--- a/switch.py
+++ b/switch.py
@@ -2,6 +2,7 @@ from sccs_layout_check import check_sccs, directory_path, path
 import sys
 import os
 import json
+import shutil
 check_sccs()
 
 branch_to_switch = sys.argv[2] if len(sys.argv) > 2 else None
@@ -24,3 +25,15 @@ except Exception as e:
     sys.exit(1)
 
 latest_commit_on_branch = commit_history["history"]["commit_order"][f"{commit_history['history']['latest_commit_number']}"]
+
+if not os.path.isfile(os.path.join(directory_path, ".sccs", "objects", "docx", f"{latest_commit_on_branch}.docx")):
+    print(f"Error: Commit object '{latest_commit_on_branch}' not found.")
+    sys.exit(1)
+
+confirmation = input(f"Are you sure you want to switch to branch '{branch_to_switch}'? This will overwrite all uncommitted changes (Y/N): ")
+
+if confirmation.lower() == "y": confirmation = True 
+else:  confirmation = False
+   
+if confirmation:
+    shutil.copy2(os.path.join(directory_path, ".sccs", "objects", "docx", f"{latest_commit_on_branch}.docx"), os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx"))

--- a/switch.py
+++ b/switch.py
@@ -40,3 +40,27 @@ if confirmation:
         shutil.copy2(os.path.join(directory_path, ".sccs", "objects", "docx", f"{latest_commit_on_branch}.docx"), os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx"))
     except Exception as e:
         print(f"Error switching to branch '{branch_to_switch}': {e}")
+        sys.exit(1)
+try: 
+    with open(os.path.join(directory_path, ".sccs", "current_branch", "current_branch.json"), "r") as f:
+        try:
+            current_branch = json.load(f)
+        except Exception as e:
+            print(f"Error reading current branch information: {e}")
+            sys.exit(1)
+except Exception as e:
+    print(f"Error accessing current branch information: {e}")
+    sys.exit(1)
+
+current_branch["current_branch"] = branch_to_switch
+
+try:
+    with open(os.path.join(directory_path, ".sccs", "current_branch", "current_branch.json"), "w") as f:
+        try:
+            json.dump(current_branch, f)
+        except Exception as e:
+            print(f"Error writing current branch information: {e}")
+            sys.exit(1)
+except Exception as e:
+    print(f"Error updating current branch information: {e}")
+    sys.exit(1)

--- a/switch.py
+++ b/switch.py
@@ -11,7 +11,7 @@ branch_to_switch = sys.argv[2] if len(sys.argv) > 2 else None
 if branch_to_switch:
     branch_to_switch = sanitize_dirname(branch_to_switch)
 
-if not branch_to_switch:
+if not branch_to_switch or len(branch_to_switch) == 0:
     print("No branch specified. Please provide a branch name to switch to.")
     sys.exit(1)
 

--- a/switch.py
+++ b/switch.py
@@ -1,6 +1,7 @@
 from sccs_layout_check import check_sccs, directory_path, path
 import sys
-
+import os
+import json
 check_sccs()
 
 branch_to_switch = sys.argv[2] if len(sys.argv) > 2 else None
@@ -9,3 +10,17 @@ if not branch_to_switch:
     print("No branch specified. Please provide a branch name to switch to.")
     sys.exit(1)
 
+try:
+    with open(os.path.join(directory_path, ".sccs",  "branches", branch_to_switch, "history", "commit_history.json"), "r") as f:
+        try:
+            commit_history = json.load(f)
+            
+        except Exception as e:
+            print(f"Error parsing commit history for branch '{branch_to_switch}': {e}")
+            sys.exit(1)
+
+except Exception as e: 
+    print(f"Error reading commit history for branch '{branch_to_switch}': {e}")
+    sys.exit(1)
+
+latest_commit_on_branch = commit_history["history"]["commit_order"][f"{commit_history['history']['latest_commit_number']}"]

--- a/switch.py
+++ b/switch.py
@@ -72,8 +72,7 @@ except Exception as e:
     sys.exit(1)
 
 if not commit_file_hash == hashed_file:
-    print(f"Error: Cannot switch to branch '{branch_to_switch}' because the current file has uncommitted changes, or the byte content does not match the latest commit. Please commit your changes before switching branches.
-          ")
+    print(f"Error: Cannot switch to branch '{branch_to_switch}' because the current file has uncommitted changes, or the byte content does not match the latest commit. Please commit your changes before switching branches.")
     sys.exit(1)
 
 try:

--- a/switch.py
+++ b/switch.py
@@ -64,3 +64,5 @@ try:
 except Exception as e:
     print(f"Error updating current branch information: {e}")
     sys.exit(1)
+
+print(f"Successfully switched to branch '{branch_to_switch}'.")


### PR DESCRIPTION
# Switch Branches command for SCCS CLI #41 

This PR focuses on creating a new command for the SCCS CLI, `sccs switch <branch_name>`, which allows user to change branches of an SCCS repository.

## SCCS (py/sh), SCCS.bat

- Add tunnel to branch.py for `sccs switch` command.
- Update fallback message and instructions comment.

## Switch.py

- Run check_sccs
- Get entered branch name to switch to.
- Get the latest commit of that branch by opening the branch's `commit_history.json` file.
- Copy that docx commit to the repo's docx, overwriting the current file.
- Change the current branch in `current_branch.json`

## Branch.py

- Switch to created branch by changing the current branch in `current_branch.json`.

## Type of Change

- [ ] Bugfix
- [x] Feature
- [ ] Documentation

      
