### PR TITLE
Feat: check inputs to make sure they are not empty

### DIFF
--- a/commit.py
+++ b/commit.py
@@ -42,7 +42,11 @@ with open(config_path, "r", encoding="utf-8", newline="\n") as config_file:
     email = config.get("email")
 
 # Get commit message
-commit_message = input("Enter commit message: ")
+commit_message = input("Enter commit message: ").strip()
+
+if commit_message == "":
+    print("Commit message cannot be empty.")
+    sys.exit(1)
 
 timestamp = datetime.now().isoformat()
 

--- a/init.py
+++ b/init.py
@@ -49,8 +49,17 @@ else:
     sys.exit(1)
 
 # Get user inputted name and email
-name = input("Enter your name: ")
-email = input("Enter your email: ")
+name = input("Enter your name: ").strip()
+
+if name == "":
+    print("Name cannot be empty.")
+    sys.exit(1)
+
+email = input("Enter your email: ").strip()
+
+if email == "":
+    print("Email cannot be empty.")
+    sys.exit(1)
 
 timestamp = datetime.now().isoformat()
 initial_commit_message = "initial commit (This is a default commit message for initial version)"

--- a/open.py
+++ b/open.py
@@ -10,7 +10,11 @@ from sccs_layout_check import check_sccs
 check_sccs()
 
 # Get user inputted commit path
-commit_path = input("Enter the path to the commit file (.docx): ")
+commit_path = input("Enter the path to the commit file (.docx): ").strip()
+
+if commit_path == "":
+    print("Commit file path cannot be empty.")
+    sys.exit(1)
 
 if not Path(commit_path).is_file() or Path(commit_path).suffix.lower() != ".docx":
     print("Invalid commit file path, make sure the file exists and is a .docx file")


### PR DESCRIPTION
# Make Sure Inputs Are Non-Empty

This PR adds the `.strip()` to each input and checks if it equals `""`, to confirm it is not empty. If the input is empty, print an error message and `sys.exit(1)`.

## Commit.py

- Update commit message input.

## Init.py

- Update name and email inputs.

## Open.py

- Update commit path input.

## Type of Change

- [x] Bugfix
- [ ] Feature
- [ ] Documentation