### PR TITLE
fix: capitalize error messages and add periods

### DIFF
--- a/init.py
+++ b/init.py
@@ -15,12 +15,12 @@ path = sys.argv[2] if len(sys.argv) > 2 else None
 if path: 
     directory_path = Path(path).with_suffix('')
 else:
-    print("No file path provided")
+    print("No file path provided.")
     sys.exit(1)
 
 # Check if the directory already contains an SCCS initialization
 if Path(os.path.join(directory_path, ".sccs")).is_dir():
-    print("This file has already been initialized with SCCS")
+    print("This file has already been initialized with SCCS.")
     sys.exit(1)
 
 # Check if the path ends with .docx and exists
@@ -45,7 +45,7 @@ elif path and Path(path).suffix.lower() == ".docx" and Path(path).is_file():
 # if not, exit  
 
 else: 
-    print("Invalid file path, make sure the file exists and is a .docx file")
+    print("Invalid file path, make sure the file exists and is a .docx file.")
     sys.exit(1)
 
 # Get user inputted name and email


### PR DESCRIPTION
## What changed

Fixed three error messages in init.py to have proper capitalization and punctuation:

- 'No file path provided' → 'No file path provided.'
- 'This file has already been initialized with SCCS' → 'This file has already been initialized with SCCS.'
- 'Invalid file path, make sure the file exists and is a .docx file' → 'Invalid file path, make sure the file exists and is a .docx file.'

## Why

The error messages were inconsistent with the rest of the repo. All error messages should start with a capital letter and end with a period for consistency.

## How it was tested

- Verified all error messages in init.py now have proper capitalization and punctuation
- Checked that the changes don't break any existing functionality

## Issue

Fixes #59