### PR TITLE
Feat/#69 feature use function blocks for sccs status

### DIFF
--- a/status.py
+++ b/status.py
@@ -9,11 +9,12 @@ from sccs_layout_check import directory_path
 from sccs_layout_check import path
 
 from sccs_layout_check import check_sccs
+CURRENT_BRANCH_PATH = os.path.join(directory_path, ".sccs", "current_branch", "current_branch.json")
 
 check_sccs()
 
-current_branch_path = os.path.join(directory_path, ".sccs", "current_branch", "current_branch.json")
-with open(current_branch_path, "r", encoding="utf-8", newline="\n") as current_branch_file:
+
+with open(CURRENT_BRANCH_PATH, "r", encoding="utf-8", newline="\n") as current_branch_file:
     current_branch = json.load(current_branch_file).get("current_branch")
 
 try:

--- a/status.py
+++ b/status.py
@@ -33,9 +33,9 @@ def hash_current_docx_binary(file_path):
 
     return hashed_file
 
-def get_latest_commit_hash_file():
+def get_latest_commit_hash_file(current_branch):
     # get the latest commit filename hash from commit history
-    history_path = os.path.join(directory_path, ".sccs", "branches", get_current_branch(), "history", "commit_history.json")
+    history_path = os.path.join(directory_path, ".sccs", "branches", current_branch, "history", "commit_history.json")
     if not Path(history_path).is_file():
         print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
         sys.exit(1)
@@ -58,10 +58,10 @@ def get_latest_commit_hash_file():
     
     return latest_commit_hash
 
-def get_latest_commit_file_binary_hash():
+def get_latest_commit_file_binary_hash(current_branch):
     # get the hash of the latest committed file
-    latest_commit_hash = get_latest_commit_hash_file()
-    latest_commit_file_hash_path = os.path.join(directory_path, ".sccs", "branches", get_current_branch(), "commit_file_hash", "commit_file_hash.json")
+    latest_commit_hash = get_latest_commit_hash_file(current_branch)
+    latest_commit_file_hash_path = os.path.join(directory_path, ".sccs", "branches", current_branch, "commit_file_hash", "commit_file_hash.json")
     if not Path(latest_commit_file_hash_path).is_file():
         print("Latest commit file hash not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
         sys.exit(1)
@@ -93,4 +93,5 @@ def print_changes_message(old_hash, new_hash):
 
 if __name__ == "__main__":
     check_sccs()
-    print_changes_message(get_latest_commit_file_binary_hash(), hash_current_docx_binary(path))
+    current_branch = get_current_branch()
+    print_changes_message(get_latest_commit_file_binary_hash(current_branch), hash_current_docx_binary(path))

--- a/status.py
+++ b/status.py
@@ -50,29 +50,34 @@ def get_latest_commit_hash_file():
     
     return latest_commit_hash
 
+def get_latest_commit_file_hash():
+    # get the hash of the latest committed file
+    latest_commit_file_hash_path = os.path.join(directory_path, ".sccs", "branches", current_branch, "commit_file_hash", "commit_file_hash.json")
+    if not Path(latest_commit_file_hash_path).is_file():
+        print("Latest commit file hash not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        sys.exit(1)
+
+    try:
+        with open(latest_commit_file_hash_path, "r", encoding="utf-8", newline="\n") as f:
+            commit_file_hash_data = json.load(f)
+            latest_commit_file_hash = commit_file_hash_data.get(latest_commit_hash)
+    except (json.JSONDecodeError, KeyError, TypeError, OSError) as e:
+        print("Latest commit file hash is missing or corrupted. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        sys.exit(1)
+
+    if not latest_commit_file_hash:
+        print("Latest commit file hash is missing. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        sys.exit(1)
+    
+    return latest_commit_file_hash
+
 current_branch = get_current_branch()
 
 hashed_file = hash_current_docx_binary(path)
 
 latest_commit_hash = get_latest_commit_hash_file()
 
-# get the hash of the latest committed file
-latest_commit_file_hash_path = os.path.join(directory_path, ".sccs", "branches", current_branch, "commit_file_hash", "commit_file_hash.json")
-if not Path(latest_commit_file_hash_path).is_file():
-    print("Latest commit file hash not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
-    sys.exit(1)
-
-try:
-    with open(latest_commit_file_hash_path, "r", encoding="utf-8", newline="\n") as f:
-        commit_file_hash_data = json.load(f)
-        latest_commit_file_hash = commit_file_hash_data.get(latest_commit_hash)
-except (json.JSONDecodeError, KeyError, TypeError, OSError) as e:
-    print("Latest commit file hash is missing or corrupted. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
-    sys.exit(1)
-
-if not latest_commit_file_hash:
-    print("Latest commit file hash is missing. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
-    sys.exit(1)
+latest_commit_file_hash = get_latest_commit_file_hash()
 
 if hashed_file == latest_commit_file_hash:
     print("No changes detected since the latest commit. Nothing to commit.")

--- a/status.py
+++ b/status.py
@@ -83,15 +83,15 @@ def get_latest_commit_file_binary_hash(current_branch):
 def compare_hashes(old_hash, new_hash):
     return old_hash == new_hash
 
-def print_changes_message(old_hash, new_hash):
+def print_changes_message_and_exit(old_hash, new_hash):
     if compare_hashes(old_hash, new_hash):
         print("No changes detected since the latest commit. Nothing to commit.")
         sys.exit(0)
     else:
         print("Changes detected since the latest commit. You can proceed with committing these changes.")
-        sys.exit(0)
+        sys.exit(1)
 
 if __name__ == "__main__":
     check_sccs()
     current_branch = get_current_branch()
-    print_changes_message(get_latest_commit_file_binary_hash(current_branch), hash_current_docx_binary(path))
+    print_changes_message_and_exit(get_latest_commit_file_binary_hash(current_branch), hash_current_docx_binary(path))

--- a/status.py
+++ b/status.py
@@ -12,6 +12,9 @@ def get_current_branch():
         with open(CURRENT_BRANCH_PATH, "r", encoding="utf-8", newline="\n") as current_branch_file:
             try:
                 current_branch = json.load(current_branch_file).get("current_branch")
+                if not current_branch:
+                    print("Current branch is missing from JSON. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+                    sys.exit(1)
             except json.JSONDecodeError as e:
                 print(f"Error decoding JSON from current branch file: {e}")
                 sys.exit(1)
@@ -70,6 +73,9 @@ def get_latest_commit_file_binary_hash(current_branch):
         with open(latest_commit_file_hash_path, "r", encoding="utf-8", newline="\n") as f:
             commit_file_hash_data = json.load(f)
             latest_commit_file_hash = commit_file_hash_data.get(latest_commit_hash)
+            if not latest_commit_file_hash:
+                print("Latest commit file hash is missing from JSON. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+                sys.exit(1)
     except (json.JSONDecodeError, KeyError, TypeError, OSError) as e:
         print(f"Error reading latest commit file hash: {e}")
         sys.exit(1)

--- a/status.py
+++ b/status.py
@@ -14,13 +14,21 @@ CURRENT_BRANCH_PATH = os.path.join(directory_path, ".sccs", "current_branch", "c
 check_sccs()
 
 def get_current_branch():
-    with open(CURRENT_BRANCH_PATH, "r", encoding="utf-8", newline="\n") as current_branch_file:
-        current_branch = json.load(current_branch_file).get("current_branch")
+    try:
+        with open(CURRENT_BRANCH_PATH, "r", encoding="utf-8", newline="\n") as current_branch_file:
+            try:
+                current_branch = json.load(current_branch_file).get("current_branch")
+            except json.JSONDecodeError as e:
+                print(f"Error decoding JSON from current branch file: {e}")
+                sys.exit(1)
+    except Exception as e:
+        print(f"Error reading current branch: {e}")
+        sys.exit(1)
     return current_branch
 
-def hash_current_docx_binary(path):
+def hash_current_docx_binary(file_path):
     try:
-        with open(path, "rb") as f:
+        with open(file_path, "rb") as f:
             hasher = hashlib.sha256()
             for chunk in iter(lambda: f.read(65536), b""):
                 hasher.update(chunk)
@@ -40,10 +48,14 @@ def get_latest_commit_hash_file():
 
     try:
         with open(history_path, "r", encoding="utf-8", newline="\n") as history_file:
-            history = json.load(history_file)
-            latest_commit_hash = history["history"]["latest_commit"]
-    except (json.JSONDecodeError, KeyError, TypeError):
-        print("History file is missing or corrupted. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+            try:
+                history = json.load(history_file)
+                latest_commit_hash = history["history"]["latest_commit"]
+            except (json.JSONDecodeError, KeyError, TypeError) as e:
+                print(f"Error reading history file: {e}")
+                sys.exit(1)
+    except Exception as e:
+        print(f"Error opening history file: {e}")
         sys.exit(1)
 
     if not latest_commit_hash:
@@ -65,7 +77,7 @@ def get_latest_commit_file_binary_hash():
             commit_file_hash_data = json.load(f)
             latest_commit_file_hash = commit_file_hash_data.get(latest_commit_hash)
     except (json.JSONDecodeError, KeyError, TypeError, OSError) as e:
-        print("Latest commit file hash is missing or corrupted. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        print(f"Error reading latest commit file hash: {e}")
         sys.exit(1)
 
     if not latest_commit_file_hash:

--- a/status.py
+++ b/status.py
@@ -71,8 +71,17 @@ def get_latest_commit_file_binary_hash(current_branch):
 
     try:
         with open(latest_commit_file_hash_path, "r", encoding="utf-8", newline="\n") as f:
-            commit_file_hash_data = json.load(f)
-            latest_commit_file_hash = commit_file_hash_data.get(latest_commit_hash)
+            try:
+                commit_file_hash_data = json.load(f)
+            except json.JSONDecodeError as e:
+                print(f"Error decoding JSON from latest commit file hash: {e}")
+                sys.exit(1)
+            try:
+                latest_commit_file_hash = commit_file_hash_data.get(latest_commit_hash)
+            except Exception as e:
+                print(f"Error retrieving latest commit file hash: {e}")
+                sys.exit(1)
+                
             if not latest_commit_file_hash:
                 print("Latest commit file hash is missing from JSON. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
                 sys.exit(1)

--- a/status.py
+++ b/status.py
@@ -31,7 +31,7 @@ def hash_current_docx_binary(path):
 
 def get_latest_commit_hash_file():
     # get the latest commit filename hash from commit history
-    history_path = os.path.join(directory_path, ".sccs", "branches", current_branch, "history", "commit_history.json")
+    history_path = os.path.join(directory_path, ".sccs", "branches", get_current_branch(), "history", "commit_history.json")
     if not Path(history_path).is_file():
         print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
         sys.exit(1)
@@ -52,7 +52,8 @@ def get_latest_commit_hash_file():
 
 def get_latest_commit_file_hash():
     # get the hash of the latest committed file
-    latest_commit_file_hash_path = os.path.join(directory_path, ".sccs", "branches", current_branch, "commit_file_hash", "commit_file_hash.json")
+    latest_commit_hash = get_latest_commit_hash_file()
+    latest_commit_file_hash_path = os.path.join(directory_path, ".sccs", "branches", get_current_branch(), "commit_file_hash", "commit_file_hash.json")
     if not Path(latest_commit_file_hash_path).is_file():
         print("Latest commit file hash not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
         sys.exit(1)
@@ -68,18 +69,13 @@ def get_latest_commit_file_hash():
     if not latest_commit_file_hash:
         print("Latest commit file hash is missing. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
         sys.exit(1)
-    
+
     return latest_commit_file_hash
 
-current_branch = get_current_branch()
+def compare_hashes(old_hash, new_hash):
+    return old_hash == new_hash
 
-hashed_file = hash_current_docx_binary(path)
-
-latest_commit_hash = get_latest_commit_hash_file()
-
-latest_commit_file_hash = get_latest_commit_file_hash()
-
-if hashed_file == latest_commit_file_hash:
+if compare_hashes(hash_current_docx_binary(path), get_latest_commit_file_hash()):
     print("No changes detected since the latest commit. Nothing to commit.")
     sys.exit(0)
 

--- a/status.py
+++ b/status.py
@@ -29,6 +29,8 @@ def hash_current_docx_binary(path):
         print(f"Error processing .docx file: {e}")
         sys.exit(1)
 
+    return hashed_file
+
 def get_latest_commit_hash_file():
     # get the latest commit filename hash from commit history
     history_path = os.path.join(directory_path, ".sccs", "branches", get_current_branch(), "history", "commit_history.json")

--- a/status.py
+++ b/status.py
@@ -3,12 +3,8 @@ from pathlib import Path
 import sys
 import hashlib
 import json
+from sccs_layout_check import directory_path, path, check_sccs
 
-from sccs_layout_check import directory_path
-
-from sccs_layout_check import path
-
-from sccs_layout_check import check_sccs
 CURRENT_BRANCH_PATH = os.path.join(directory_path, ".sccs", "current_branch", "current_branch.json")
 
 def get_current_branch():

--- a/status.py
+++ b/status.py
@@ -52,7 +52,7 @@ def get_latest_commit_hash_file():
     
     return latest_commit_hash
 
-def get_latest_commit_file_hash():
+def get_latest_commit_file_binary_hash():
     # get the hash of the latest committed file
     latest_commit_hash = get_latest_commit_hash_file()
     latest_commit_file_hash_path = os.path.join(directory_path, ".sccs", "branches", get_current_branch(), "commit_file_hash", "commit_file_hash.json")
@@ -77,10 +77,12 @@ def get_latest_commit_file_hash():
 def compare_hashes(old_hash, new_hash):
     return old_hash == new_hash
 
-if compare_hashes(hash_current_docx_binary(path), get_latest_commit_file_hash()):
-    print("No changes detected since the latest commit. Nothing to commit.")
-    sys.exit(0)
+def print_changes_message(old_hash, new_hash):
+    if compare_hashes(old_hash, new_hash):
+        print("No changes detected since the latest commit. Nothing to commit.")
+        sys.exit(0)
+    else:
+        print("Changes detected since the latest commit. You can proceed with committing these changes.")
+        sys.exit(0)
 
-else: 
-    print("Changes detected since the latest commit. You can proceed with committing these changes.")
-    sys.exit(0)
+print_changes_message(get_latest_commit_file_binary_hash(), hash_current_docx_binary(path))

--- a/status.py
+++ b/status.py
@@ -29,27 +29,32 @@ def hash_current_docx_binary(path):
         print(f"Error processing .docx file: {e}")
         sys.exit(1)
 
+def get_latest_commit_hash_file():
+    # get the latest commit filename hash from commit history
+    history_path = os.path.join(directory_path, ".sccs", "branches", current_branch, "history", "commit_history.json")
+    if not Path(history_path).is_file():
+        print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        sys.exit(1)
+
+    try:
+        with open(history_path, "r", encoding="utf-8", newline="\n") as history_file:
+            history = json.load(history_file)
+            latest_commit_hash = history["history"]["latest_commit"]
+    except (json.JSONDecodeError, KeyError, TypeError):
+        print("History file is missing or corrupted. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        sys.exit(1)
+
+    if not latest_commit_hash:
+        print("History file is missing the latest commit information. Please reinitialize SCCS for this file.") 
+        sys.exit(1)
+    
+    return latest_commit_hash
+
 current_branch = get_current_branch()
 
 hashed_file = hash_current_docx_binary(path)
 
-# get the latest commit filename hash from commit history
-history_path = os.path.join(directory_path, ".sccs", "branches", current_branch, "history", "commit_history.json")
-if not Path(history_path).is_file():
-    print("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
-    sys.exit(1)
-
-try:
-    with open(history_path, "r", encoding="utf-8", newline="\n") as history_file:
-        history = json.load(history_file)
-        latest_commit_hash = history["history"]["latest_commit"]
-except (json.JSONDecodeError, KeyError, TypeError):
-    print("History file is missing or corrupted. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
-    sys.exit(1)
-
-if not latest_commit_hash:
-    print("History file is missing the latest commit information. Please reinitialize SCCS for this file.") 
-    sys.exit(1)
+latest_commit_hash = get_latest_commit_hash_file()
 
 # get the hash of the latest committed file
 latest_commit_file_hash_path = os.path.join(directory_path, ".sccs", "branches", current_branch, "commit_file_hash", "commit_file_hash.json")

--- a/status.py
+++ b/status.py
@@ -11,8 +11,6 @@ from sccs_layout_check import path
 from sccs_layout_check import check_sccs
 CURRENT_BRANCH_PATH = os.path.join(directory_path, ".sccs", "current_branch", "current_branch.json")
 
-check_sccs()
-
 def get_current_branch():
     try:
         with open(CURRENT_BRANCH_PATH, "r", encoding="utf-8", newline="\n") as current_branch_file:
@@ -97,4 +95,6 @@ def print_changes_message(old_hash, new_hash):
         print("Changes detected since the latest commit. You can proceed with committing these changes.")
         sys.exit(0)
 
-print_changes_message(get_latest_commit_file_binary_hash(), hash_current_docx_binary(path))
+if __name__ == "__main__":
+    check_sccs()
+    print_changes_message(get_latest_commit_file_binary_hash(), hash_current_docx_binary(path))

--- a/status.py
+++ b/status.py
@@ -13,19 +13,25 @@ CURRENT_BRANCH_PATH = os.path.join(directory_path, ".sccs", "current_branch", "c
 
 check_sccs()
 
+def get_current_branch():
+    with open(CURRENT_BRANCH_PATH, "r", encoding="utf-8", newline="\n") as current_branch_file:
+        current_branch = json.load(current_branch_file).get("current_branch")
+    return current_branch
 
-with open(CURRENT_BRANCH_PATH, "r", encoding="utf-8", newline="\n") as current_branch_file:
-    current_branch = json.load(current_branch_file).get("current_branch")
+def hash_current_docx_binary(path):
+    try:
+        with open(path, "rb") as f:
+            hasher = hashlib.sha256()
+            for chunk in iter(lambda: f.read(65536), b""):
+                hasher.update(chunk)
+            hashed_file = hasher.hexdigest()
+    except Exception as e:
+        print(f"Error processing .docx file: {e}")
+        sys.exit(1)
 
-try:
-    with open(path, "rb") as f:
-        hasher = hashlib.sha256()
-        for chunk in iter(lambda: f.read(65536), b""):
-            hasher.update(chunk)
-        hashed_file = hasher.hexdigest()
-except Exception as e:
-    print(f"Error processing .docx file: {e}")
-    sys.exit(1)
+current_branch = get_current_branch()
+
+hashed_file = hash_current_docx_binary(path)
 
 # get the latest commit filename hash from commit history
 history_path = os.path.join(directory_path, ".sccs", "branches", current_branch, "history", "commit_history.json")


### PR DESCRIPTION
# Use Function Block-Level Code for SCCS Status #69 

This PR focuses on refactoring `status.py` to use block-level functions instead of top-level code to increase readability for new contributors

## Status.py

- Refactor to use block-level functions instead of top-level code to increase readability for new contributors
- Exit with status code `1` if changes are detected.

## Type of Change

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Refactor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed exit code behaviour for change detection—the application now properly exits with code 0 when no changes are detected and code 1 when changes are identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->