### PR TITLE
feat: add vscode spellcheck configuration for sccs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "sccs"
+    ]
+}


### PR DESCRIPTION
Update VSCODE `settings.json` spellcheck configuration to approve `sccs` as a real word.