### PR TITLE
Feat/#66 feature use function blocks for sccs open

### DIFF
--- a/open.py
+++ b/open.py
@@ -13,15 +13,20 @@ def get_commit_path_input():
     commit_path = input("Enter the path to the commit file (.docx): ").strip()
     return commit_path
 
+def check_commit_path_input():
+    commit_path = get_commit_path_input()
+    if commit_path == "":
+        print("Commit file path cannot be empty.")
+        sys.exit(1)
+
+    if not Path(commit_path).is_file() or Path(commit_path).suffix.lower() != ".docx":
+        print("Invalid commit file path, make sure the file exists and is a .docx file")
+        sys.exit(1)
+    return commit_path
+
+check_commit_path_input()
+
 commit_path = get_commit_path_input()
-
-if commit_path == "":
-    print("Commit file path cannot be empty.")
-    sys.exit(1)
-
-if not Path(commit_path).is_file() or Path(commit_path).suffix.lower() != ".docx":
-    print("Invalid commit file path, make sure the file exists and is a .docx file")
-    sys.exit(1)
 
 confirm = input(f"Are you sure you want to overwrite '{os.path.basename(path)}' with the contents of '{os.path.basename(commit_path)}'?\nThis action will replace the current content of the .docx file. (Y/N): ").strip().lower()
 if confirm != 'y':

--- a/open.py
+++ b/open.py
@@ -38,6 +38,9 @@ def check_changes():
 def open_file_commit():
     shutil.copy2(commit_path, path)
 
+def print_confirmation_message():
+    print(f"File '{os.path.basename(path)}' has been updated with the contents of '{os.path.basename(commit_path)}'.")
+
 commit_path = get_commit_path_input()
 
 check_commit_path_input()
@@ -48,4 +51,4 @@ check_changes()
 
 open_file_commit()
 
-print(f"File '{os.path.basename(path)}' has been updated with the contents of '{os.path.basename(commit_path)}'.")
+print_confirmation_message()

--- a/open.py
+++ b/open.py
@@ -14,7 +14,6 @@ def get_commit_path_input():
     return commit_path
 
 def check_commit_path_input():
-    commit_path = get_commit_path_input()
     if commit_path == "":
         print("Commit file path cannot be empty.")
         sys.exit(1)
@@ -36,7 +35,11 @@ def check_changes():
         sys.exit(0)
 
 def open_file_commit():
-    shutil.copy2(commit_path, path)
+    try:
+        shutil.copy2(commit_path, path)
+    except Exception as e:
+        print(f"Error occurred while updating the file: {e}")
+        sys.exit(1)
 
 def print_confirmation_message():
     print(f"File '{os.path.basename(path)}' has been updated with the contents of '{os.path.basename(commit_path)}'.")

--- a/open.py
+++ b/open.py
@@ -51,9 +51,9 @@ if __name__ == "__main__":
 
     check_commit_path_input(commit_path)
 
-    confirm_before_proceeding(commit_path, path)
-
     check_changes(commit_path, path)
+    
+    confirm_before_proceeding(commit_path, path)
 
     open_file_commit(commit_path, path)
 

--- a/open.py
+++ b/open.py
@@ -35,6 +35,9 @@ def check_changes():
         print("The commit file is the same as the current file. No changes will be made.")
         sys.exit(0)
 
+def open_file_commit():
+    shutil.copy2(commit_path, path)
+
 commit_path = get_commit_path_input()
 
 check_commit_path_input()
@@ -43,6 +46,6 @@ confirm_before_proceeding()
 
 check_changes()
 
-shutil.copy2(commit_path, path)
+open_file_commit()
 
 print(f"File '{os.path.basename(path)}' has been updated with the contents of '{os.path.basename(commit_path)}'.")

--- a/open.py
+++ b/open.py
@@ -7,7 +7,7 @@ from sccs_layout_check import path
 
 from sccs_layout_check import check_sccs
 
-check_sccs()
+
 
 def get_commit_path_input():
     commit_path = input("Enter the path to the commit file (.docx): ").strip()
@@ -44,14 +44,17 @@ def open_file_commit(commit_path, path):
 def print_confirmation_message(commit_path, path):
     print(f"File '{os.path.basename(path)}' has been updated with the contents of '{os.path.basename(commit_path)}'.")
 
-commit_path = get_commit_path_input()
+if __name__ == "__main__":
+    check_sccs()
 
-check_commit_path_input(commit_path)
+    commit_path = get_commit_path_input()
 
-confirm_before_proceeding(commit_path, path)
+    check_commit_path_input(commit_path)
 
-check_changes(commit_path, path)
+    confirm_before_proceeding(commit_path, path)
 
-open_file_commit(commit_path, path)
+    check_changes(commit_path, path)
 
-print_confirmation_message(commit_path, path)
+    open_file_commit(commit_path, path)
+
+    print_confirmation_message(commit_path, path)

--- a/open.py
+++ b/open.py
@@ -30,7 +30,7 @@ def check_changes(commit_path, path):
         print("The commit file is the same as the current file. No changes will be made.")
         sys.exit(0)
 
-def open_file_commit(commit_path, path):
+def copy_file_commit(commit_path, path):
     try:
         shutil.copy2(commit_path, path)
     except Exception as e:
@@ -51,6 +51,6 @@ if __name__ == "__main__":
 
     confirm_before_proceeding(commit_path, path)
 
-    open_file_commit(commit_path, path)
+    copy_file_commit(commit_path, path)
 
     print_confirmation_message(commit_path, path)

--- a/open.py
+++ b/open.py
@@ -17,7 +17,6 @@ def check_commit_path_input(commit_path):
     if not Path(commit_path).is_file() or Path(commit_path).suffix.lower() != ".docx":
         print("Invalid commit file path, make sure the file exists and is a .docx file")
         sys.exit(1)
-    return commit_path
 
 def confirm_before_proceeding(commit_path, path):
     confirm = input(f"Are you sure you want to overwrite '{os.path.basename(path)}' with the contents of '{os.path.basename(commit_path)}'?\nThis action will replace the current content of the .docx file. (Y/N): ").strip().lower()

--- a/open.py
+++ b/open.py
@@ -13,7 +13,7 @@ def get_commit_path_input():
     commit_path = input("Enter the path to the commit file (.docx): ").strip()
     return commit_path
 
-def check_commit_path_input():
+def check_commit_path_input(commit_path):
     if commit_path == "":
         print("Commit file path cannot be empty.")
         sys.exit(1)
@@ -23,35 +23,35 @@ def check_commit_path_input():
         sys.exit(1)
     return commit_path
 
-def confirm_before_proceeding():
+def confirm_before_proceeding(commit_path, path):
     confirm = input(f"Are you sure you want to overwrite '{os.path.basename(path)}' with the contents of '{os.path.basename(commit_path)}'?\nThis action will replace the current content of the .docx file. (Y/N): ").strip().lower()
     if confirm != 'y':
         print("Update canceled.")
         sys.exit(0)
 
-def check_changes():
+def check_changes(commit_path, path):
     if Path(path).exists() and Path(commit_path).exists() and os.path.samefile(path, commit_path):
         print("The commit file is the same as the current file. No changes will be made.")
         sys.exit(0)
 
-def open_file_commit():
+def open_file_commit(commit_path, path):
     try:
         shutil.copy2(commit_path, path)
     except Exception as e:
         print(f"Error occurred while updating the file: {e}")
         sys.exit(1)
 
-def print_confirmation_message():
+def print_confirmation_message(commit_path, path):
     print(f"File '{os.path.basename(path)}' has been updated with the contents of '{os.path.basename(commit_path)}'.")
 
 commit_path = get_commit_path_input()
 
-check_commit_path_input()
+check_commit_path_input(commit_path)
 
-confirm_before_proceeding()
+confirm_before_proceeding(commit_path, path)
 
-check_changes()
+check_changes(commit_path, path)
 
-open_file_commit()
+open_file_commit(commit_path, path)
 
-print_confirmation_message()
+print_confirmation_message(commit_path, path)

--- a/open.py
+++ b/open.py
@@ -3,11 +3,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from sccs_layout_check import path
-
-from sccs_layout_check import check_sccs
-
-
+from sccs_layout_check import path, check_sccs
 
 def get_commit_path_input():
     commit_path = input("Enter the path to the commit file (.docx): ").strip()
@@ -52,7 +48,7 @@ if __name__ == "__main__":
     check_commit_path_input(commit_path)
 
     check_changes(commit_path, path)
-    
+
     confirm_before_proceeding(commit_path, path)
 
     open_file_commit(commit_path, path)

--- a/open.py
+++ b/open.py
@@ -30,14 +30,18 @@ def confirm_before_proceeding():
         print("Update canceled.")
         sys.exit(0)
 
+def check_changes():
+    if Path(path).exists() and Path(commit_path).exists() and os.path.samefile(path, commit_path):
+        print("The commit file is the same as the current file. No changes will be made.")
+        sys.exit(0)
+
 commit_path = get_commit_path_input()
 
 check_commit_path_input()
 
 confirm_before_proceeding()
-if Path(path).exists() and Path(commit_path).exists() and os.path.samefile(path, commit_path):
-    print("The commit file is the same as the current file. No changes will be made.")
-    sys.exit(0)
+
+check_changes()
 
 shutil.copy2(commit_path, path)
 

--- a/open.py
+++ b/open.py
@@ -9,8 +9,11 @@ from sccs_layout_check import check_sccs
 
 check_sccs()
 
-# Get user inputted commit path
-commit_path = input("Enter the path to the commit file (.docx): ").strip()
+def get_commit_path_input():
+    commit_path = input("Enter the path to the commit file (.docx): ").strip()
+    return commit_path
+
+commit_path = get_commit_path_input()
 
 if commit_path == "":
     print("Commit file path cannot be empty.")

--- a/open.py
+++ b/open.py
@@ -3,7 +3,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from sccs_layout_check import path, check_sccs
+from sccs_layout_check import path, check_sccs, directory_path
 
 def get_commit_path_input():
     commit_path = input("Enter the path to the commit file (.docx): ").strip()
@@ -19,7 +19,7 @@ def check_commit_path_input(commit_path):
         sys.exit(1)
 
 def confirm_before_proceeding(commit_path, path):
-    confirm = input(f"Are you sure you want to overwrite '{os.path.basename(path)}' with the contents of '{os.path.basename(commit_path)}'?\nThis action will replace the current content of the .docx file. (Y/N): ").strip().lower()
+    confirm = input(f"Are you sure you want to overwrite '{directory_path}/{os.path.basename(path)}' with the contents of '{directory_path}/{os.path.basename(commit_path)}'?\nThis action will replace the current content of the .docx file. (Y/N): ").strip().lower()
     if confirm != 'y':
         print("Update canceled.")
         sys.exit(0)

--- a/open.py
+++ b/open.py
@@ -24,15 +24,17 @@ def check_commit_path_input():
         sys.exit(1)
     return commit_path
 
-check_commit_path_input()
+def confirm_before_proceeding():
+    confirm = input(f"Are you sure you want to overwrite '{os.path.basename(path)}' with the contents of '{os.path.basename(commit_path)}'?\nThis action will replace the current content of the .docx file. (Y/N): ").strip().lower()
+    if confirm != 'y':
+        print("Update canceled.")
+        sys.exit(0)
 
 commit_path = get_commit_path_input()
 
-confirm = input(f"Are you sure you want to overwrite '{os.path.basename(path)}' with the contents of '{os.path.basename(commit_path)}'?\nThis action will replace the current content of the .docx file. (Y/N): ").strip().lower()
-if confirm != 'y':
-    print("Update canceled.")
-    sys.exit(0)
+check_commit_path_input()
 
+confirm_before_proceeding()
 if Path(path).exists() and Path(commit_path).exists() and os.path.samefile(path, commit_path):
     print("The commit file is the same as the current file. No changes will be made.")
     sys.exit(0)


### PR DESCRIPTION
# Use Function Level Blocks for `sccs open` #66

This PR focuses on using function block level code modules instead of top level code to increase readability for contributors.

## Open.py

Use function block level code modules instead of top level code to increase readability for contributors.


List all files, what changes were made

## Type of Change

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Refactor 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced script structure with improved input validation and confirmation prompts before file operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->