### PR TITLE
Refactor/#71 feature use function blocks for sccs tunnel shell file

### DIFF
--- a/sccs
+++ b/sccs
@@ -12,7 +12,7 @@ def get_script_directory():
     return os.path.dirname(os.path.realpath(__file__))
 
 def check_if_command_is_valid(command, COMMANDS):
-    return True if command in COMMANDS else False
+    return command in COMMANDS
 
 def print_unknown_command_error(command):
     print(f"Unknown command: {command}")

--- a/sccs
+++ b/sccs
@@ -23,7 +23,7 @@ def print_unknown_command_error(command):
 def run_command(command, script_directory):
     sys.exit(subprocess.run([sys.executable, os.path.join(script_directory, f"{command}.py")] + sys.argv[1:]).returncode)
 
-def run_unknown_error_or_run_command(command, script_directory, COMMANDS):
+def execute_command(command, script_directory, COMMANDS):
     if not check_if_command_is_valid(command, COMMANDS):
         print_unknown_command_error(command)
     run_command(command, script_directory)
@@ -32,6 +32,6 @@ command = get_entered_command()
 
 script_directory = get_script_directory()
 
-run_unknown_error_or_run_command(command, script_directory, COMMANDS)
+execute_command(command, script_directory, COMMANDS)
 
 # If on MacOS / Linux, move this file, commit.py, init.py, open.py, log.py, diff.py, status.py, help.py, branch.py , and switch.py to /usr/local/bin and make it executable with `chmod +x /usr/local/bin/sccs`

--- a/sccs
+++ b/sccs
@@ -3,40 +3,21 @@ import sys
 import subprocess
 import os
 
+COMMANDS = ["init", "commit", "open", "log", "diff", "status", "help", "branch", "switch"]
+
 command = sys.argv[1] if len(sys.argv) > 1 else None
 
 script_directory = os.path.dirname(os.path.realpath(__file__))
-if command == "init":
-    sys.exit(subprocess.run([sys.executable, os.path.join(script_directory, "init.py")] + sys.argv[1:]).returncode)
 
-elif command == "commit":
-    sys.exit(subprocess.run([sys.executable, os.path.join(script_directory, "commit.py")] + sys.argv[1:]).returncode)
+for c in COMMANDS:
+    if command == c:
+        sys.exit(subprocess.run([sys.executable, os.path.join(script_directory, f"{c}.py")] + sys.argv[1:]).returncode)
 
-elif command == "open":
-    sys.exit(subprocess.run([sys.executable, os.path.join(script_directory, "open.py")] + sys.argv[1:]).returncode)
-
-elif command == "log":
-    sys.exit(subprocess.run([sys.executable, os.path.join(script_directory, "log.py")] + sys.argv[1:]).returncode)
-
-elif command == "diff":
-    sys.exit(subprocess.run([sys.executable, os.path.join(script_directory, "diff.py")] + sys.argv[1:]).returncode)
-    
-elif command == "status":
-    sys.exit(subprocess.run([sys.executable, os.path.join(script_directory, "status.py")] + sys.argv[1:]).returncode)
-
-elif command == "help":
-    sys.exit(subprocess.run([sys.executable, os.path.join(script_directory, "help.py")] + sys.argv[1:]).returncode)
-
-elif command == "branch":
-    sys.exit(subprocess.run([sys.executable, os.path.join(script_directory, "branch.py")] + sys.argv[1:]).returncode)
-
-elif command == "switch":
-    sys.exit(subprocess.run([sys.executable, os.path.join(script_directory, "switch.py")] + sys.argv[1:]).returncode)
-
-else: 
-    print(f"Unknown command: {command}")
-    print("Invalid command. Please use 'init', 'commit', 'open', 'log', 'diff', 'status', 'help', 'branch', or 'switch', along with required arguments.")
-    print("For help, use the 'sccs help' command.")
-    sys.exit(1)
+    else: 
+        print(f"Unknown command: {command}")
+        print("Invalid command. Please use 'init', 'commit', 'open', 'log', 'diff', 'status', 'help', 'branch', or 'switch', along with required arguments.")
+        print("For help, use the 'sccs help' command.")
+        sys.exit(1)
+        break
 
 # If on MacOS / Linux, move this file, commit.py, init.py, open.py, log.py, diff.py, status.py, help.py, branch.py , and switch.py to /usr/local/bin and make it executable with `chmod +x /usr/local/bin/sccs`

--- a/sccs
+++ b/sccs
@@ -28,10 +28,12 @@ def execute_command(command, script_directory, COMMANDS):
         print_unknown_command_error(command)
     run_command(command, script_directory)
 
-command = get_entered_command()
+if __name__ == "__main__":
 
-script_directory = get_script_directory()
+    command = get_entered_command()
 
-execute_command(command, script_directory, COMMANDS)
+    script_directory = get_script_directory()
+    
+    execute_command(command, script_directory, COMMANDS)
 
 # If on MacOS / Linux, move this file, commit.py, init.py, open.py, log.py, diff.py, status.py, help.py, branch.py , and switch.py to /usr/local/bin and make it executable with `chmod +x /usr/local/bin/sccs`

--- a/sccs
+++ b/sccs
@@ -5,19 +5,33 @@ import os
 
 COMMANDS = ["init", "commit", "open", "log", "diff", "status", "help", "branch", "switch"]
 
-command = sys.argv[1] if len(sys.argv) > 1 else None
+def get_entered_command():
+    return sys.argv[1] if len(sys.argv) > 1 else None
 
-script_directory = os.path.dirname(os.path.realpath(__file__))
+def get_script_directory():
+    return os.path.dirname(os.path.realpath(__file__))
 
-for c in COMMANDS:
-    if command == c:
-        sys.exit(subprocess.run([sys.executable, os.path.join(script_directory, f"{c}.py")] + sys.argv[1:]).returncode)
+def check_if_command_is_valid(command, COMMANDS):
+    return True if command in COMMANDS else False
 
-    else: 
-        print(f"Unknown command: {command}")
-        print("Invalid command. Please use 'init', 'commit', 'open', 'log', 'diff', 'status', 'help', 'branch', or 'switch', along with required arguments.")
-        print("For help, use the 'sccs help' command.")
-        sys.exit(1)
-        break
+def print_unknown_command_error(command):
+    print(f"Unknown command: {command}")
+    print("Invalid command. Please use 'init', 'commit', 'open', 'log', 'diff', 'status', 'help', 'branch', or 'switch', along with required arguments.")
+    print("For help, use the 'sccs help' command.")
+    sys.exit(1)
+
+def run_command(command, script_directory):
+    sys.exit(subprocess.run([sys.executable, os.path.join(script_directory, f"{command}.py")] + sys.argv[1:]).returncode)
+
+def run_unknown_error_or_run_command(command, script_directory, COMMANDS):
+    if not check_if_command_is_valid(command, COMMANDS):
+        print_unknown_command_error(command)
+    run_command(command, script_directory)
+
+command = get_entered_command()
+
+script_directory = get_script_directory()
+
+run_unknown_error_or_run_command(command, script_directory, COMMANDS)
 
 # If on MacOS / Linux, move this file, commit.py, init.py, open.py, log.py, diff.py, status.py, help.py, branch.py , and switch.py to /usr/local/bin and make it executable with `chmod +x /usr/local/bin/sccs`


### PR DESCRIPTION
# Use Function Level Modules for SCCS SH File #71 

This PR focuses on using function level block modules instead of top level code to increase readability and improve test creation.

## SCCS (SH/PY)

 Use function level block modules instead of top level code to increase readability and improve test creation.

## Type of Change

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Refactor

/gemini review
