### PR TITLE
Refactor/#68 feature use function blocks for sccs diff

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -37,18 +37,22 @@ def convert_current_docx_to_html(docx_path):
 
     return docx_current_version_html
 
+def get_commit_html(commit_path):
+    try:
+        with open(commit_path, "r", encoding="utf-8", newline="\n") as f:
+            commit_html = f.read()
+    except Exception as e:
+        print(f"Error reading commit file: {e}")
+        sys.exit(1)
+    return commit_html
+
 check_sccs()
 
 validate_commit(COMMIT_TO_DIFF)
 
 docx_current_version_html = convert_current_docx_to_html(DOCX_CURRENT_VERSION)
 
-try:
-    with open(COMMIT_TO_DIFF, "r", encoding="utf-8", newline="\n") as f:
-        commit_html = f.read()
-except Exception as e:
-    print(f"Error reading commit file: {e}")
-    sys.exit(1)
+commit_html = get_commit_html(COMMIT_TO_DIFF)
 
 def remove_inline_semantics(html):
     soup = html

--- a/diff.py
+++ b/diff.py
@@ -178,23 +178,25 @@ def write_redline_html_file(redline, filename="redline.html"):
     with open(filename, "w", encoding="utf-8", newline="\n") as f:
         f.write(wrap_html(str(strip_number_attribute(redline))))
 
-check_sccs()
+if __name__ == "__main__":
 
-validate_commit(COMMIT_TO_DIFF)
+    check_sccs()
 
-docx_current_version_html = convert_current_docx_to_html(DOCX_CURRENT_VERSION)
+    validate_commit(COMMIT_TO_DIFF)
 
-commit_html = get_commit_html(COMMIT_TO_DIFF)
+    docx_current_version_html = convert_current_docx_to_html(DOCX_CURRENT_VERSION)
 
-bs4_docx_current_version_soup = convert_html_to_soup(docx_current_version_html)
+    commit_html = get_commit_html(COMMIT_TO_DIFF)
 
-docx_current_version_list = format_bs4_html_list(bs4_docx_current_version_soup)
+    bs4_docx_current_version_soup = convert_html_to_soup(docx_current_version_html)
 
-bs4_commit_soup = convert_html_to_soup(commit_html)
-commit_list = format_bs4_html_list(bs4_commit_soup)
+    docx_current_version_list = format_bs4_html_list(bs4_docx_current_version_soup)
 
-opcodes = get_opcodes(bs4_commit_soup, bs4_docx_current_version_soup)
+    bs4_commit_soup = convert_html_to_soup(commit_html)
+    commit_list = format_bs4_html_list(bs4_commit_soup)
 
-redline = format_redline_html(get_redline_html(bs4_commit_soup), opcodes, commit_list, docx_current_version_list)
+    opcodes = get_opcodes(bs4_commit_soup, bs4_docx_current_version_soup)
 
-write_redline_html_file(redline)
+    redline = format_redline_html(get_redline_html(bs4_commit_soup), opcodes, commit_list, docx_current_version_list)
+
+    write_redline_html_file(redline)

--- a/diff.py
+++ b/diff.py
@@ -139,14 +139,6 @@ def insert_tag(html, new_changed_strings, i1):
     
     return soup
 
-check_sccs()
-
-validate_commit(COMMIT_TO_DIFF)
-
-docx_current_version_html = convert_current_docx_to_html(DOCX_CURRENT_VERSION)
-
-commit_html = get_commit_html(COMMIT_TO_DIFF)
-
 def remove_inline_semantics(html):
     soup = html
     for tag in soup.find_all():
@@ -158,6 +150,13 @@ def remove_inline_semantics(html):
             continue
     return soup
 
+check_sccs()
+
+validate_commit(COMMIT_TO_DIFF)
+
+docx_current_version_html = convert_current_docx_to_html(DOCX_CURRENT_VERSION)
+
+commit_html = get_commit_html(COMMIT_TO_DIFF)
 
 bs4_docx_current_version_soup = BeautifulSoup(docx_current_version_html, "html.parser")
 

--- a/diff.py
+++ b/diff.py
@@ -150,6 +150,9 @@ def remove_inline_semantics(html):
             continue
     return soup
 
+def convert_html_to_soup(html):
+    return BeautifulSoup(html, "html.parser")
+
 check_sccs()
 
 validate_commit(COMMIT_TO_DIFF)
@@ -158,16 +161,15 @@ docx_current_version_html = convert_current_docx_to_html(DOCX_CURRENT_VERSION)
 
 commit_html = get_commit_html(COMMIT_TO_DIFF)
 
-bs4_docx_current_version_soup = BeautifulSoup(docx_current_version_html, "html.parser")
+bs4_docx_current_version_soup = convert_html_to_soup(docx_current_version_html)
 
 docx_current_version_list = tags_to_list(number_tags(remove_inline_semantics(copy.copy(bs4_docx_current_version_soup))))
 
-bs4_commit_soup = BeautifulSoup(commit_html, "html.parser")
+bs4_commit_soup = convert_html_to_soup(commit_html)
 commit_list = tags_to_list(number_tags(remove_inline_semantics(copy.copy(bs4_commit_soup))))
 
 opcodes = difflib.SequenceMatcher(None, tags_to_list(remove_inline_semantics(copy.copy(bs4_commit_soup))), tags_to_list(remove_inline_semantics(copy.copy(bs4_docx_current_version_soup)))).get_opcodes()
 redline = number_tags(remove_inline_semantics(copy.copy(bs4_commit_soup)))
-
 
 for opcode in reversed(opcodes):
     tag, i1, i2, j1, j2 = opcode

--- a/diff.py
+++ b/diff.py
@@ -9,7 +9,7 @@ import copy
 COMMIT_TO_DIFF = sys.argv[2] if len(sys.argv) > 2 else None 
 DOCX_CURRENT_VERSION = os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx")
 
-def validate_commit(commit_to_diff):
+def validate_commit(commit_to_diff, docx_current_version):
     if not commit_to_diff:
         print("No commit file specified.")
         sys.exit(1)
@@ -22,7 +22,7 @@ def validate_commit(commit_to_diff):
         print("Commit file is not a .html file. Please provide a valid .html commit file.")
         sys.exit(1)
 
-    if not Path(DOCX_CURRENT_VERSION).is_file():
+    if not Path(docx_current_version).is_file():
         print("Docx file not found. Re-initialize SCCS for this file with 'sccs init <file_path>'")
         sys.exit(1)
 
@@ -182,7 +182,7 @@ if __name__ == "__main__":
 
     check_sccs()
 
-    validate_commit(COMMIT_TO_DIFF)
+    validate_commit(COMMIT_TO_DIFF, DOCX_CURRENT_VERSION)
 
     docx_current_version_html = convert_current_docx_to_html(DOCX_CURRENT_VERSION)
 

--- a/diff.py
+++ b/diff.py
@@ -141,13 +141,11 @@ def insert_tag(html, new_changed_strings, i1):
 
 def remove_inline_semantics(html):
     soup = html
-    for tag in soup.find_all():
-        if tag.name in ["b", "i", "u", "strong", "em"]:
-            tag.unwrap()
-        
+    for tag in soup.find_all(["b", "i", "u", "strong", "em", "style"]):
         if tag.name == "style":
             tag.decompose()
-            continue
+        else:
+            tag.unwrap()
     return soup
 
 def convert_html_to_soup(html):

--- a/diff.py
+++ b/diff.py
@@ -159,6 +159,9 @@ def format_bs4_html_list(bs4_obj):
 def get_opcodes(commit_soup, current_soup):
     return difflib.SequenceMatcher(None, tags_to_list(remove_inline_semantics(copy.copy(commit_soup))), tags_to_list(remove_inline_semantics(copy.copy(current_soup)))).get_opcodes()
 
+def get_redline_html(commit_soup):
+    return number_tags(remove_inline_semantics(copy.copy(commit_soup)))
+
 check_sccs()
 
 validate_commit(COMMIT_TO_DIFF)
@@ -175,7 +178,7 @@ bs4_commit_soup = convert_html_to_soup(commit_html)
 commit_list = format_bs4_html_list(bs4_commit_soup)
 
 opcodes = get_opcodes(bs4_commit_soup, bs4_docx_current_version_soup)
-redline = number_tags(remove_inline_semantics(copy.copy(bs4_commit_soup)))
+redline = get_redline_html(bs4_commit_soup)
 
 for opcode in reversed(opcodes):
     tag, i1, i2, j1, j2 = opcode

--- a/diff.py
+++ b/diff.py
@@ -174,6 +174,11 @@ def format_redline_html(redline, opcodes):
             redline = insert_tag(redline, new_changed_strings, i1)
         if tag =="delete":
             redline = delete_tag(redline, old_changed_strings)
+    return redline
+
+def write_redline_html_file(redline, filename="redline.html"):
+    with open(filename, "w", encoding="utf-8", newline="\n") as f:
+        f.write(wrap_html(str(strip_number_attribute(redline))))
 
 check_sccs()
 
@@ -195,5 +200,4 @@ redline = get_redline_html(bs4_commit_soup)
 
 format_redline_html(redline, opcodes)
 
-with open("redline.html", "w", encoding="utf-8", newline="\n") as f:
-    f.write(wrap_html(str(strip_number_attribute(redline))))
+write_redline_html_file(redline)

--- a/diff.py
+++ b/diff.py
@@ -26,11 +26,11 @@ def validate_commit(commit_to_diff):
         print("Docx file not found. Re-initialize SCCS for this file with 'sccs init <file_path>'")
         sys.exit(1)
 
-
+check_sccs()
 
 validate_commit(COMMIT_TO_DIFF)
 
-check_sccs()
+
 
 try:
     with open(DOCX_CURRENT_VERSION, "rb") as f:

--- a/diff.py
+++ b/diff.py
@@ -46,25 +46,6 @@ def get_commit_html(commit_path):
         sys.exit(1)
     return commit_html
 
-check_sccs()
-
-validate_commit(COMMIT_TO_DIFF)
-
-docx_current_version_html = convert_current_docx_to_html(DOCX_CURRENT_VERSION)
-
-commit_html = get_commit_html(COMMIT_TO_DIFF)
-
-def remove_inline_semantics(html):
-    soup = html
-    for tag in soup.find_all():
-        if tag.name in ["b", "i", "u", "strong", "em"]:
-            tag.unwrap()
-        
-        if tag.name == "style":
-            tag.decompose()
-            continue
-    return soup
-
 def number_tags(html):
     soup = html
     for i, tag in enumerate(soup.find_all()):
@@ -92,6 +73,26 @@ def get_data_number(tag_list):
             if parsed_tag.get('data-number') is not None:
                 data_number.add(parsed_tag.get('data-number'))
     return data_number
+
+check_sccs()
+
+validate_commit(COMMIT_TO_DIFF)
+
+docx_current_version_html = convert_current_docx_to_html(DOCX_CURRENT_VERSION)
+
+commit_html = get_commit_html(COMMIT_TO_DIFF)
+
+def remove_inline_semantics(html):
+    soup = html
+    for tag in soup.find_all():
+        if tag.name in ["b", "i", "u", "strong", "em"]:
+            tag.unwrap()
+        
+        if tag.name == "style":
+            tag.decompose()
+            continue
+    return soup
+
 
 bs4_docx_current_version_soup = BeautifulSoup(docx_current_version_html, "html.parser")
 

--- a/diff.py
+++ b/diff.py
@@ -156,6 +156,9 @@ def convert_html_to_soup(html):
 def format_bs4_html_list(bs4_obj):
     tags_to_list(number_tags(remove_inline_semantics(copy.copy(bs4_obj))))
 
+def get_opcodes(commit_soup, current_soup):
+    return difflib.SequenceMatcher(None, tags_to_list(remove_inline_semantics(copy.copy(commit_soup))), tags_to_list(remove_inline_semantics(copy.copy(current_soup)))).get_opcodes()
+
 check_sccs()
 
 validate_commit(COMMIT_TO_DIFF)
@@ -171,7 +174,7 @@ docx_current_version_list = format_bs4_html_list(bs4_docx_current_version_soup)
 bs4_commit_soup = convert_html_to_soup(commit_html)
 commit_list = format_bs4_html_list(bs4_commit_soup)
 
-opcodes = difflib.SequenceMatcher(None, tags_to_list(remove_inline_semantics(copy.copy(bs4_commit_soup))), tags_to_list(remove_inline_semantics(copy.copy(bs4_docx_current_version_soup)))).get_opcodes()
+opcodes = get_opcodes(bs4_commit_soup, bs4_docx_current_version_soup)
 redline = number_tags(remove_inline_semantics(copy.copy(bs4_commit_soup)))
 
 for opcode in reversed(opcodes):

--- a/diff.py
+++ b/diff.py
@@ -162,6 +162,19 @@ def get_opcodes(commit_soup, current_soup):
 def get_redline_html(commit_soup):
     return number_tags(remove_inline_semantics(copy.copy(commit_soup)))
 
+def format_redline_html(redline, opcodes):
+    for opcode in reversed(opcodes):
+        tag, i1, i2, j1, j2 = opcode
+        
+        old_changed_strings = commit_list[i1:i2]
+        new_changed_strings = docx_current_version_list[j1:j2]
+        if tag == "replace":
+            redline = replace_tag(redline, old_changed_strings, new_changed_strings)
+        if tag =="insert":
+            redline = insert_tag(redline, new_changed_strings, i1)
+        if tag =="delete":
+            redline = delete_tag(redline, old_changed_strings)
+
 check_sccs()
 
 validate_commit(COMMIT_TO_DIFF)
@@ -180,16 +193,7 @@ commit_list = format_bs4_html_list(bs4_commit_soup)
 opcodes = get_opcodes(bs4_commit_soup, bs4_docx_current_version_soup)
 redline = get_redline_html(bs4_commit_soup)
 
-for opcode in reversed(opcodes):
-    tag, i1, i2, j1, j2 = opcode
-    
-    old_changed_strings = commit_list[i1:i2]
-    new_changed_strings = docx_current_version_list[j1:j2]
-    if tag == "replace":
-        redline = replace_tag(redline, old_changed_strings, new_changed_strings)
-    if tag =="insert":
-        redline = insert_tag(redline, new_changed_strings, i1)
-    if tag =="delete":
-        redline = delete_tag(redline, old_changed_strings)
+format_redline_html(redline, opcodes)
+
 with open("redline.html", "w", encoding="utf-8", newline="\n") as f:
     f.write(wrap_html(str(strip_number_attribute(redline))))

--- a/diff.py
+++ b/diff.py
@@ -194,8 +194,7 @@ bs4_commit_soup = convert_html_to_soup(commit_html)
 commit_list = format_bs4_html_list(bs4_commit_soup)
 
 opcodes = get_opcodes(bs4_commit_soup, bs4_docx_current_version_soup)
-redline = get_redline_html(bs4_commit_soup)
 
-format_redline_html(redline, opcodes, commit_list, docx_current_version_list)
+redline = format_redline_html(get_redline_html(bs4_commit_soup), opcodes, commit_list, docx_current_version_list)
 
 write_redline_html_file(redline)

--- a/diff.py
+++ b/diff.py
@@ -4,13 +4,11 @@ import sys
 from bs4 import BeautifulSoup
 import mammoth
 import difflib
-from sccs_layout_check import check_sccs, wrap_html
+from sccs_layout_check import check_sccs, wrap_html, directory_path
 import copy
 
 
 commit_to_diff = sys.argv[2] if len(sys.argv) > 2 else None 
-
-directory_path = os.getcwd()
 
 docx_current_version = os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx")
 

--- a/diff.py
+++ b/diff.py
@@ -26,20 +26,22 @@ def validate_commit(commit_to_diff):
         print("Docx file not found. Re-initialize SCCS for this file with 'sccs init <file_path>'")
         sys.exit(1)
 
+def convert_docx_to_html(docx_path):
+    try:
+        with open(docx_path, "rb") as f:
+            docx_current_version_html = mammoth.convert_to_html(f).value
+
+    except Exception as e:
+        print(f"Error converting .docx to HTML: {e}")
+        sys.exit(1)
+
+    return docx_current_version_html
+
 check_sccs()
 
 validate_commit(COMMIT_TO_DIFF)
 
-
-
-try:
-    with open(DOCX_CURRENT_VERSION, "rb") as f:
-        docx_current_version_html = mammoth.convert_to_html(f).value
-
-except Exception as e:
-    print(f"Error converting .docx to HTML: {e}")
-    sys.exit(1)
-
+docx_current_version_html = convert_docx_to_html(DOCX_CURRENT_VERSION)
 
 try:
     with open(COMMIT_TO_DIFF, "r", encoding="utf-8", newline="\n") as f:

--- a/diff.py
+++ b/diff.py
@@ -153,6 +153,9 @@ def remove_inline_semantics(html):
 def convert_html_to_soup(html):
     return BeautifulSoup(html, "html.parser")
 
+def format_bs4_html_list(bs4_obj):
+    tags_to_list(number_tags(remove_inline_semantics(copy.copy(bs4_obj))))
+
 check_sccs()
 
 validate_commit(COMMIT_TO_DIFF)
@@ -163,10 +166,10 @@ commit_html = get_commit_html(COMMIT_TO_DIFF)
 
 bs4_docx_current_version_soup = convert_html_to_soup(docx_current_version_html)
 
-docx_current_version_list = tags_to_list(number_tags(remove_inline_semantics(copy.copy(bs4_docx_current_version_soup))))
+docx_current_version_list = format_bs4_html_list(bs4_docx_current_version_soup)
 
 bs4_commit_soup = convert_html_to_soup(commit_html)
-commit_list = tags_to_list(number_tags(remove_inline_semantics(copy.copy(bs4_commit_soup))))
+commit_list = format_bs4_html_list(bs4_commit_soup)
 
 opcodes = difflib.SequenceMatcher(None, tags_to_list(remove_inline_semantics(copy.copy(bs4_commit_soup))), tags_to_list(remove_inline_semantics(copy.copy(bs4_docx_current_version_soup)))).get_opcodes()
 redline = number_tags(remove_inline_semantics(copy.copy(bs4_commit_soup)))

--- a/diff.py
+++ b/diff.py
@@ -152,9 +152,8 @@ def remove_inline_semantics(html):
 
 def convert_html_to_soup(html):
     return BeautifulSoup(html, "html.parser")
-
 def format_bs4_html_list(bs4_obj):
-    tags_to_list(number_tags(remove_inline_semantics(copy.copy(bs4_obj))))
+    return tags_to_list(number_tags(remove_inline_semantics(copy.copy(bs4_obj))))
 def get_opcodes(commit_soup, current_soup):
     return difflib.SequenceMatcher(None, tags_to_list(remove_inline_semantics(copy.copy(commit_soup))), tags_to_list(remove_inline_semantics(copy.copy(current_soup)))).get_opcodes()
 

--- a/diff.py
+++ b/diff.py
@@ -74,36 +74,6 @@ def get_data_number(tag_list):
                 data_number.add(parsed_tag.get('data-number'))
     return data_number
 
-check_sccs()
-
-validate_commit(COMMIT_TO_DIFF)
-
-docx_current_version_html = convert_current_docx_to_html(DOCX_CURRENT_VERSION)
-
-commit_html = get_commit_html(COMMIT_TO_DIFF)
-
-def remove_inline_semantics(html):
-    soup = html
-    for tag in soup.find_all():
-        if tag.name in ["b", "i", "u", "strong", "em"]:
-            tag.unwrap()
-        
-        if tag.name == "style":
-            tag.decompose()
-            continue
-    return soup
-
-
-bs4_docx_current_version_soup = BeautifulSoup(docx_current_version_html, "html.parser")
-
-docx_current_version_list = tags_to_list(number_tags(remove_inline_semantics(copy.copy(bs4_docx_current_version_soup))))
-
-bs4_commit_soup = BeautifulSoup(commit_html, "html.parser")
-commit_list = tags_to_list(number_tags(remove_inline_semantics(copy.copy(bs4_commit_soup))))
-
-opcodes = difflib.SequenceMatcher(None, tags_to_list(remove_inline_semantics(copy.copy(bs4_commit_soup))), tags_to_list(remove_inline_semantics(copy.copy(bs4_docx_current_version_soup)))).get_opcodes()
-redline = number_tags(remove_inline_semantics(copy.copy(bs4_commit_soup)))
-
 def delete_tag(html, old_changed_strings):
     old_data_numbers = get_data_number(old_changed_strings)
     soup = html
@@ -168,6 +138,37 @@ def insert_tag(html, new_changed_strings, i1):
         soup.append(frag)    
     
     return soup
+
+check_sccs()
+
+validate_commit(COMMIT_TO_DIFF)
+
+docx_current_version_html = convert_current_docx_to_html(DOCX_CURRENT_VERSION)
+
+commit_html = get_commit_html(COMMIT_TO_DIFF)
+
+def remove_inline_semantics(html):
+    soup = html
+    for tag in soup.find_all():
+        if tag.name in ["b", "i", "u", "strong", "em"]:
+            tag.unwrap()
+        
+        if tag.name == "style":
+            tag.decompose()
+            continue
+    return soup
+
+
+bs4_docx_current_version_soup = BeautifulSoup(docx_current_version_html, "html.parser")
+
+docx_current_version_list = tags_to_list(number_tags(remove_inline_semantics(copy.copy(bs4_docx_current_version_soup))))
+
+bs4_commit_soup = BeautifulSoup(commit_html, "html.parser")
+commit_list = tags_to_list(number_tags(remove_inline_semantics(copy.copy(bs4_commit_soup))))
+
+opcodes = difflib.SequenceMatcher(None, tags_to_list(remove_inline_semantics(copy.copy(bs4_commit_soup))), tags_to_list(remove_inline_semantics(copy.copy(bs4_docx_current_version_soup)))).get_opcodes()
+redline = number_tags(remove_inline_semantics(copy.copy(bs4_commit_soup)))
+
 
 for opcode in reversed(opcodes):
     tag, i1, i2, j1, j2 = opcode

--- a/diff.py
+++ b/diff.py
@@ -6,32 +6,34 @@ import mammoth
 import difflib
 from sccs_layout_check import check_sccs, wrap_html, directory_path
 import copy
+COMMIT_TO_DIFF = sys.argv[2] if len(sys.argv) > 2 else None 
+DOCX_CURRENT_VERSION = os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx")
+
+def validate_commit(commit_to_diff):
+    if not commit_to_diff:
+        print("No commit file specified.")
+        sys.exit(1)
+
+    if not Path(commit_to_diff).is_file():
+        print("Commit file not found. Please provide a valid commit file path.")
+        sys.exit(1)
+
+    if Path(commit_to_diff).suffix.lower() != ".html":
+        print("Commit file is not a .html file. Please provide a valid .html commit file.")
+        sys.exit(1)
+
+    if not Path(DOCX_CURRENT_VERSION).is_file():
+        print("Docx file not found. Re-initialize SCCS for this file with 'sccs init <file_path>'")
+        sys.exit(1)
 
 
-commit_to_diff = sys.argv[2] if len(sys.argv) > 2 else None 
 
-docx_current_version = os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx")
-
-if not commit_to_diff:
-    print("No commit file specified.")
-    sys.exit(1)
-
-if not Path(commit_to_diff).is_file():
-    print("Commit file not found. Please provide a valid commit file path.")
-    sys.exit(1)
-
-if Path(commit_to_diff).suffix.lower() != ".html":
-    print("Commit file is not a .html file. Please provide a valid .html commit file.")
-    sys.exit(1)
-
-if not Path(docx_current_version).is_file():
-    print("Docx file not found. Re-initialize SCCS for this file with 'sccs init <file_path>'")
-    sys.exit(1)
+validate_commit(COMMIT_TO_DIFF)
 
 check_sccs()
 
 try:
-    with open(docx_current_version, "rb") as f:
+    with open(DOCX_CURRENT_VERSION, "rb") as f:
         docx_current_version_html = mammoth.convert_to_html(f).value
 
 except Exception as e:
@@ -40,7 +42,7 @@ except Exception as e:
 
 
 try:
-    with open(commit_to_diff, "r", encoding="utf-8", newline="\n") as f:
+    with open(COMMIT_TO_DIFF, "r", encoding="utf-8", newline="\n") as f:
         commit_html = f.read()
 except Exception as e:
     print(f"Error reading commit file: {e}")

--- a/diff.py
+++ b/diff.py
@@ -155,14 +155,13 @@ def convert_html_to_soup(html):
 
 def format_bs4_html_list(bs4_obj):
     tags_to_list(number_tags(remove_inline_semantics(copy.copy(bs4_obj))))
-
 def get_opcodes(commit_soup, current_soup):
     return difflib.SequenceMatcher(None, tags_to_list(remove_inline_semantics(copy.copy(commit_soup))), tags_to_list(remove_inline_semantics(copy.copy(current_soup)))).get_opcodes()
 
 def get_redline_html(commit_soup):
     return number_tags(remove_inline_semantics(copy.copy(commit_soup)))
 
-def format_redline_html(redline, opcodes):
+def format_redline_html(redline, opcodes, commit_list, docx_current_version_list):
     for opcode in reversed(opcodes):
         tag, i1, i2, j1, j2 = opcode
         
@@ -198,6 +197,6 @@ commit_list = format_bs4_html_list(bs4_commit_soup)
 opcodes = get_opcodes(bs4_commit_soup, bs4_docx_current_version_soup)
 redline = get_redline_html(bs4_commit_soup)
 
-format_redline_html(redline, opcodes)
+format_redline_html(redline, opcodes, commit_list, docx_current_version_list)
 
 write_redline_html_file(redline)

--- a/diff.py
+++ b/diff.py
@@ -26,7 +26,7 @@ def validate_commit(commit_to_diff):
         print("Docx file not found. Re-initialize SCCS for this file with 'sccs init <file_path>'")
         sys.exit(1)
 
-def convert_docx_to_html(docx_path):
+def convert_current_docx_to_html(docx_path):
     try:
         with open(docx_path, "rb") as f:
             docx_current_version_html = mammoth.convert_to_html(f).value
@@ -41,7 +41,7 @@ check_sccs()
 
 validate_commit(COMMIT_TO_DIFF)
 
-docx_current_version_html = convert_docx_to_html(DOCX_CURRENT_VERSION)
+docx_current_version_html = convert_current_docx_to_html(DOCX_CURRENT_VERSION)
 
 try:
     with open(COMMIT_TO_DIFF, "r", encoding="utf-8", newline="\n") as f:


### PR DESCRIPTION
# Use Function Blocks For SCCS Diff #68 

This PR focuses on using function level modules for `sccs dff` to increase readability and simplify the creation of tests.

## Diff.py

- Use function level modules for `sccs dff` to increase readability and simplify the creation of tests.

## Type of Change

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Refactor

/gemini review
