### PR TITLE
fix: read then write current branch data

### DIFF
--- a/switch.py
+++ b/switch.py
@@ -14,9 +14,19 @@ def update_current_branch(branch):
             try:
                 current_branch = json.load(f)
                 current_branch["current_branch"] = branch
-                json.dump(current_branch, f, indent=4)
             except Exception as e:
                 print(f"Error reading or updating current branch information: {e}")
+                sys.exit(1)
+    except Exception as e:
+        print(f"Error accessing current branch information: {e}")
+        sys.exit(1)
+
+    try: 
+        with open(os.path.join(directory_path, ".sccs", "current_branch", "current_branch.json"), "w", encoding="utf-8", newline="\n") as f:
+            try:
+                json.dump(current_branch, f, indent=4)
+            except Exception as e:
+                print(f"Error updating current branch information: {e}")
                 sys.exit(1)
     except Exception as e:
         print(f"Error accessing current branch information: {e}")

--- a/switch.py
+++ b/switch.py
@@ -22,7 +22,7 @@ def update_current_branch(branch):
         sys.exit(1)
 
     try: 
-        with open(os.path.join(directory_path, ".sccs", "current_branch", "current_branch.json"), "w", encoding="utf-8", newline="\n") as f:
+        with open(os.path.join("tmp"), "w", encoding="utf-8", newline="\n") as f:
             try:
                 json.dump(current_branch, f, indent=4)
             except Exception as e:
@@ -30,6 +30,12 @@ def update_current_branch(branch):
                 sys.exit(1)
     except Exception as e:
         print(f"Error accessing current branch information: {e}")
+        sys.exit(1)
+    
+    try: 
+        os.replace("tmp", os.path.join(directory_path, ".sccs", "current_branch", "current_branch.json"))
+    except Exception as e:
+        print(f"Error replacing current branch information: {e}")
         sys.exit(1)
 
 try:


### PR DESCRIPTION
# Fixes a Bug Writing to a Read File

This PR fixes a critical bug discovered by @giggitycountless where `json.dump` was attempted when the file was opened with read permission, leading to an error no matter what.

## Switch.py

- Read and load JSON in one file open
- Write modified JSON in another file open.

## Type of Change

- [x] Bugfix
- [ ] Feature
- [ ] Documentation

/gemini review