### PR TITLE
fix: move. hexdigest() call outside of loop

### DIFF
--- a/init.py
+++ b/init.py
@@ -44,14 +44,13 @@ def hash_document():
                 hasher = hashlib.sha256()
                 for chunk in iter(lambda: f.read(65536), b""):
                     hasher.update(chunk)
-                hashed_file = hasher.hexdigest()
+                return hasher.hexdigest()
             except Exception as e:
                 print(f"Error hashing .docx file: {e}")
                 sys.exit(1)
     except Exception as e:
         print(f"Error processing .docx file: {e}")
         sys.exit(1)
-    return hashed_file
 
 def convert_document_to_html():
     try: 

--- a/init.py
+++ b/init.py
@@ -44,7 +44,7 @@ def hash_document():
                 hasher = hashlib.sha256()
                 for chunk in iter(lambda: f.read(65536), b""):
                     hasher.update(chunk)
-                    hashed_file = hasher.hexdigest()
+                hashed_file = hasher.hexdigest()
             except Exception as e:
                 print(f"Error hashing .docx file: {e}")
                 sys.exit(1)


### PR DESCRIPTION
# Fixes Calling Hexdigest() inside loop

This PR fixes a bug wasting cpu by calling `hexdigest()` inside the loop, discovered by @Giggitycountless. The fix: unindent the `hexdigest()` call.

## File 1

- Unindent line 47 to move `hexdigest()`  out of for loop.
- 
## Type of Change

- [x] Bugfix
- [ ] Feature
- [ ] Documentation

`/gemini review`