### PR TITLE
Refactor/#89 feature use function blocks in switchpy

### DIFF
--- a/switch.py
+++ b/switch.py
@@ -56,6 +56,10 @@ def check_branch_to_switch(branch_to_switch, branches):
         print(f"Error: Branch '{branch_to_switch}' does not exist.")
         sys.exit(1)
 
+    if not branch_to_switch or len(branch_to_switch) == 0:
+        print("No branch specified. Please provide a branch name to switch to.")
+        sys.exit(1)
+
 def get_latest_commit(branch):
     try: 
         with open(os.path.join(directory_path, ".sccs", "branches", branch, "history", "commit_history.json"), "r", encoding="utf-8", newline="\n") as f:
@@ -92,9 +96,15 @@ def hash_current_document():
         print(f"Error processing .docx file: {e}")
         sys.exit(1)
 
-branch, branches = get_branch_data()
+def check_for_changes(branch, latest_commit_binary_hash, current_document_hash):
+    if not current_document_hash == latest_commit_binary_hash:
+        print(f"Error: The current file has uncommitted changes on the current branch '{branch}'. Please commit your changes before switching branches." )
+        sys.exit(1)
 
-check_branch_to_switch(branch_to_switch, branches)
+def sanitize_branch(branch_name):
+    return sanitize_dirname(branch_name)
+
+branch, branches = get_branch_data()
 
 latest_commit = get_latest_commit(branch)
 
@@ -102,17 +112,11 @@ latest_commit_binary_hash = get_latest_commit_binary_hash(branch, latest_commit)
 
 current_document_hash = hash_current_document()
 
-if not current_document_hash == latest_commit_binary_hash:
-    print(f"Error: The current file has uncommitted changes on the current branch '{branch}'. Please commit your changes before switching branches." )
-    sys.exit(1)
+check_for_changes(branch, latest_commit_binary_hash, current_document_hash)
 
+branch_to_switch = sanitize_branch(branch_to_switch)
 
-if branch_to_switch:
-    branch_to_switch = sanitize_dirname(branch_to_switch)
-
-if not branch_to_switch or len(branch_to_switch) == 0:
-    print("No branch specified. Please provide a branch name to switch to.")
-    sys.exit(1)
+check_branch_to_switch(branch_to_switch, branches)
 
 try:
     with open(os.path.join(directory_path, ".sccs",  "branches", branch_to_switch, "history", "commit_history.json"), "r", encoding="utf-8", newline="\n") as f:

--- a/switch.py
+++ b/switch.py
@@ -56,20 +56,24 @@ def check_branch_to_switch(branch_to_switch, branches):
         print(f"Error: Branch '{branch_to_switch}' does not exist.")
         sys.exit(1)
 
+def get_latest_commit(branch):
+    try: 
+        with open(os.path.join(directory_path, ".sccs", "branches", branch, "history", "commit_history.json"), "r", encoding="utf-8", newline="\n") as f:
+            try:
+                latest_commit = json.load(f).get("history")["latest_commit"]
+                return latest_commit
+            except Exception as e:
+                print(f"Error reading commit history for branch '{branch}': {e}")
+                sys.exit(1)
+    except Exception as e:
+        print(f"Error accessing commit history for branch '{branch}': {e}")
+        sys.exit(1)
+
 branch, branches = get_branch_data()
 
 check_branch_to_switch(branch_to_switch, branches)
 
-try: 
-    with open(os.path.join(directory_path, ".sccs", "branches", branch, "history", "commit_history.json"), "r", encoding="utf-8", newline="\n") as f:
-        try:
-            latest_commit = json.load(f).get("history")["latest_commit"]
-        except Exception as e:
-            print(f"Error reading commit history for branch '{branch}': {e}")
-            sys.exit(1)
-except Exception as e:
-    print(f"Error accessing commit history for branch '{branch}': {e}")
-    sys.exit(1)
+latest_commit = get_latest_commit(branch)
 
 try:
     with open(os.path.join(directory_path, ".sccs", "branches", branch, "commit_file_hash", "commit_file_hash.json"), "r", encoding="utf-8", newline="\n") as f:

--- a/switch.py
+++ b/switch.py
@@ -134,9 +134,9 @@ current_document_hash = hash_current_document()
 
 check_for_changes(branch, latest_commit_binary_hash, current_document_hash)
 
-branch_to_switch = sanitize_branch(branch_to_switch)
-
 check_branch_to_switch(branch_to_switch, branches)
+
+branch_to_switch = sanitize_branch(branch_to_switch)
 
 latest_commit_on_branch_to_switch = get_latest_commit(branch_to_switch)
 

--- a/switch.py
+++ b/switch.py
@@ -123,26 +123,27 @@ def copy_commit_to_main(commit):
 def print_confirmation(branch_to_switch):
     print(f"Successfully switched to branch '{branch_to_switch}'.")
 
-branch, branches = get_branch_data()
+if __name__ == "__main__":
+    branch, branches = get_branch_data()
 
-latest_commit = get_latest_commit(branch)
+    latest_commit = get_latest_commit(branch)
 
-latest_commit_binary_hash = get_latest_commit_binary_hash(branch, latest_commit)
+    latest_commit_binary_hash = get_latest_commit_binary_hash(branch, latest_commit)
 
-current_document_hash = hash_current_document()
+    current_document_hash = hash_current_document()
 
-check_for_changes(branch, latest_commit_binary_hash, current_document_hash)
+    check_for_changes(branch, latest_commit_binary_hash, current_document_hash)
 
-check_branch_to_switch(branch_to_switch, branches)
+    check_branch_to_switch(branch_to_switch, branches)
 
-branch_to_switch = sanitize_branch(branch_to_switch)
+    branch_to_switch = sanitize_branch(branch_to_switch)
 
-latest_commit_on_branch_to_switch = get_latest_commit(branch_to_switch)
+    latest_commit_on_branch_to_switch = get_latest_commit(branch_to_switch)
 
-check_commit(latest_commit_on_branch_to_switch)
+    check_commit(latest_commit_on_branch_to_switch)
 
-copy_commit_to_main(latest_commit_on_branch_to_switch)
+    copy_commit_to_main(latest_commit_on_branch_to_switch)
 
-update_current_branch(branch_to_switch)
+    update_current_branch(branch_to_switch)
 
-print_confirmation(branch_to_switch)
+    print_confirmation(branch_to_switch)

--- a/switch.py
+++ b/switch.py
@@ -69,22 +69,25 @@ def get_latest_commit(branch):
         print(f"Error accessing commit history for branch '{branch}': {e}")
         sys.exit(1)
 
+def get_latest_commit_binary_hash(branch, latest_commit):
+    try:
+        with open(os.path.join(directory_path, ".sccs", "branches", branch, "commit_file_hash", "commit_file_hash.json"), "r", encoding="utf-8", newline="\n") as f:
+            try:
+                return json.load(f).get(latest_commit)
+            except Exception as e:
+                print(f"Error reading commit file hash for branch '{branch}': {e}")
+                sys.exit(1)
+    except Exception as e:
+        print(f"Error accessing commit file hash for branch '{branch}': {e}")
+        sys.exit(1)
+
 branch, branches = get_branch_data()
 
 check_branch_to_switch(branch_to_switch, branches)
 
 latest_commit = get_latest_commit(branch)
 
-try:
-    with open(os.path.join(directory_path, ".sccs", "branches", branch, "commit_file_hash", "commit_file_hash.json"), "r", encoding="utf-8", newline="\n") as f:
-        try:
-            latest_commit_file_hash = json.load(f).get(latest_commit)
-        except Exception as e:
-            print(f"Error reading commit file hash for branch '{branch}': {e}")
-            sys.exit(1)
-except Exception as e:
-    print(f"Error accessing commit file hash for branch '{branch}': {e}")
-    sys.exit(1)
+latest_commit_binary_hash = get_latest_commit_binary_hash(branch, latest_commit)
 
 try:
     with open(path, "rb") as f:
@@ -96,7 +99,7 @@ except Exception as e:
     print(f"Error processing .docx file: {e}")
     sys.exit(1)
 
-if not hashed_file == latest_commit_file_hash:
+if not hashed_file == latest_commit_binary_hash:
     print(f"Error: The current file has uncommitted changes on the current branch '{branch}'. Please commit your changes before switching branches." )
     sys.exit(1)
 

--- a/switch.py
+++ b/switch.py
@@ -52,13 +52,15 @@ def get_branch_data():
         sys.exit(1)
 
 def check_branch_to_switch(branch_to_switch, branches):
+    if not branch_to_switch or len(branch_to_switch) == 0:
+        print("No branch specified. Please provide a branch name to switch to.")
+        sys.exit(1)
+        
     if branch_to_switch not in branches:
         print(f"Error: Branch '{branch_to_switch}' does not exist.")
         sys.exit(1)
 
-    if not branch_to_switch or len(branch_to_switch) == 0:
-        print("No branch specified. Please provide a branch name to switch to.")
-        sys.exit(1)
+    
 
 def get_latest_commit(branch):
     try: 

--- a/switch.py
+++ b/switch.py
@@ -126,6 +126,14 @@ def check_commit(commit):
         print(f"Error: Commit object '{commit}' not found.")
         sys.exit(1)
 
+def copy_commit_to_main(commit, branch):
+    try:
+        shutil.copy2(os.path.join(directory_path, ".sccs", "objects", "docx", f"{commit}.docx"), os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx"))
+    except Exception as e:
+        print(f"Error copying commit '{commit}' to main: {e}")
+        update_current_branch(branch)
+        sys.exit(1)
+
 branch, branches = get_branch_data()
 
 latest_commit = get_latest_commit(branch)
@@ -146,11 +154,6 @@ check_commit(latest_commit_on_branch_to_switch)
 
 update_current_branch(branch_to_switch)
 
-try:
-    shutil.copy2(os.path.join(directory_path, ".sccs", "objects", "docx", f"{latest_commit_on_branch_to_switch}.docx"), os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx"))
-except Exception as e:
-    print(f"Error switching to branch '{branch_to_switch}': {e}")
-    update_current_branch(branch)
-    sys.exit(1)
+copy_commit_to_main(latest_commit_on_branch_to_switch, branch)
 
 print(f"Successfully switched to branch '{branch_to_switch}'.")

--- a/switch.py
+++ b/switch.py
@@ -155,8 +155,8 @@ latest_commit_on_branch_to_switch = get_latest_commit(branch_to_switch)
 
 check_commit(latest_commit_on_branch_to_switch)
 
-update_current_branch(branch_to_switch)
-
 copy_commit_to_main(latest_commit_on_branch_to_switch, branch)
+
+update_current_branch(branch_to_switch)
 
 print_confirmation(branch_to_switch)

--- a/switch.py
+++ b/switch.py
@@ -55,24 +55,9 @@ def check_branch_to_switch(branch_to_switch, branches):
     if not branch_to_switch or len(branch_to_switch) == 0:
         print("No branch specified. Please provide a branch name to switch to.")
         sys.exit(1)
-        
+
     if branch_to_switch not in branches:
         print(f"Error: Branch '{branch_to_switch}' does not exist.")
-        sys.exit(1)
-
-    
-
-def get_latest_commit(branch):
-    try: 
-        with open(os.path.join(directory_path, ".sccs", "branches", branch, "history", "commit_history.json"), "r", encoding="utf-8", newline="\n") as f:
-            try:
-                latest_commit = json.load(f).get("history")["latest_commit"]
-                return latest_commit
-            except Exception as e:
-                print(f"Error reading commit history for branch '{branch}': {e}")
-                sys.exit(1)
-    except Exception as e:
-        print(f"Error accessing commit history for branch '{branch}': {e}")
         sys.exit(1)
 
 def get_latest_commit_binary_hash(branch, latest_commit):

--- a/switch.py
+++ b/switch.py
@@ -121,6 +121,11 @@ def get_latest_commit(branch):
         print(f"Error reading commit history for branch '{branch}': {e}")
         sys.exit(1)
 
+def check_commit(commit):
+    if not os.path.isfile(os.path.join(directory_path, ".sccs", "objects", "docx", f"{commit}.docx")):
+        print(f"Error: Commit object '{commit}' not found.")
+        sys.exit(1)
+
 branch, branches = get_branch_data()
 
 latest_commit = get_latest_commit(branch)
@@ -137,9 +142,7 @@ check_branch_to_switch(branch_to_switch, branches)
 
 latest_commit_on_branch_to_switch = get_latest_commit(branch_to_switch)
 
-if not os.path.isfile(os.path.join(directory_path, ".sccs", "objects", "docx", f"{latest_commit_on_branch_to_switch}.docx")):
-    print(f"Error: Commit object '{latest_commit_on_branch_to_switch}' not found.")
-    sys.exit(1)
+check_commit(latest_commit_on_branch_to_switch)
 
 update_current_branch(branch_to_switch)
 

--- a/switch.py
+++ b/switch.py
@@ -81,6 +81,17 @@ def get_latest_commit_binary_hash(branch, latest_commit):
         print(f"Error accessing commit file hash for branch '{branch}': {e}")
         sys.exit(1)
 
+def hash_current_document():
+    try:
+        with open(path, "rb") as f:
+            hasher = hashlib.sha256()
+            for chunk in iter(lambda: f.read(65536), b""):
+                hasher.update(chunk)
+            return hasher.hexdigest()
+    except Exception as e:
+        print(f"Error processing .docx file: {e}")
+        sys.exit(1)
+
 branch, branches = get_branch_data()
 
 check_branch_to_switch(branch_to_switch, branches)
@@ -89,17 +100,9 @@ latest_commit = get_latest_commit(branch)
 
 latest_commit_binary_hash = get_latest_commit_binary_hash(branch, latest_commit)
 
-try:
-    with open(path, "rb") as f:
-        hasher = hashlib.sha256()
-        for chunk in iter(lambda: f.read(65536), b""):
-            hasher.update(chunk)
-        hashed_file = hasher.hexdigest()
-except Exception as e:
-    print(f"Error processing .docx file: {e}")
-    sys.exit(1)
+current_document_hash = hash_current_document()
 
-if not hashed_file == latest_commit_binary_hash:
+if not current_document_hash == latest_commit_binary_hash:
     print(f"Error: The current file has uncommitted changes on the current branch '{branch}'. Please commit your changes before switching branches." )
     sys.exit(1)
 

--- a/switch.py
+++ b/switch.py
@@ -38,22 +38,27 @@ def update_current_branch(branch):
         print(f"Error replacing current branch information: {e}")
         sys.exit(1)
 
-try:
-    with open(os.path.join(directory_path, ".sccs", "current_branch", "current_branch.json"), "r", encoding="utf-8", newline="\n") as f:
-        try:
-            data = json.load(f)
-            branch = data.get("current_branch")
-            branches = data.get("branches")
-        except Exception as e:
-            print(f"Error reading current branch information: {e}")
-            sys.exit(1)
-except Exception as e:
-    print(f"Error accessing current branch information: {e}")
-    sys.exit(1)
+def get_branch_data():
+    try:
+        with open(os.path.join(directory_path, ".sccs", "current_branch", "current_branch.json"), "r", encoding="utf-8", newline="\n") as f:
+            try:
+                data = json.load(f)
+                return data.get("current_branch"), data.get("branches")
+            except Exception as e:
+                print(f"Error reading current branch information: {e}")
+                sys.exit(1)
+    except Exception as e:
+        print(f"Error accessing current branch information: {e}")
+        sys.exit(1)
 
-if branch_to_switch not in branches:
-    print(f"Error: Branch '{branch_to_switch}' does not exist.")
-    sys.exit(1)
+def check_branch_to_switch(branch_to_switch, branches):
+    if branch_to_switch not in branches:
+        print(f"Error: Branch '{branch_to_switch}' does not exist.")
+        sys.exit(1)
+
+branch, branches = get_branch_data()
+
+check_branch_to_switch(branch_to_switch, branches)
 
 try: 
     with open(os.path.join(directory_path, ".sccs", "branches", branch, "history", "commit_history.json"), "r", encoding="utf-8", newline="\n") as f:

--- a/switch.py
+++ b/switch.py
@@ -113,12 +113,11 @@ def check_commit(commit):
         print(f"Error: Commit object '{commit}' not found.")
         sys.exit(1)
 
-def copy_commit_to_main(commit, branch):
+def copy_commit_to_main(commit):
     try:
         shutil.copy2(os.path.join(directory_path, ".sccs", "objects", "docx", f"{commit}.docx"), os.path.join(directory_path, f"{os.path.basename(directory_path)}.docx"))
     except Exception as e:
         print(f"Error copying commit '{commit}' to main: {e}")
-        update_current_branch(branch)
         sys.exit(1)
 
 def print_confirmation(branch_to_switch):
@@ -142,7 +141,7 @@ latest_commit_on_branch_to_switch = get_latest_commit(branch_to_switch)
 
 check_commit(latest_commit_on_branch_to_switch)
 
-copy_commit_to_main(latest_commit_on_branch_to_switch, branch)
+copy_commit_to_main(latest_commit_on_branch_to_switch)
 
 update_current_branch(branch_to_switch)
 

--- a/switch.py
+++ b/switch.py
@@ -104,6 +104,18 @@ def check_for_changes(branch, latest_commit_binary_hash, current_document_hash):
 def sanitize_branch(branch_name):
     return sanitize_dirname(branch_name)
 
+def get_commit_history(branch):
+    try:
+        with open(os.path.join(directory_path, ".sccs",  "branches", branch, "history", "commit_history.json"), "r", encoding="utf-8", newline="\n") as f:
+            try:
+                return json.load(f)
+            except Exception as e:
+                print(f"Error parsing commit history for branch '{branch}': {e}")
+                sys.exit(1)
+    except Exception as e: 
+        print(f"Error reading commit history for branch '{branch}': {e}")
+        sys.exit(1)
+
 branch, branches = get_branch_data()
 
 latest_commit = get_latest_commit(branch)
@@ -118,18 +130,7 @@ branch_to_switch = sanitize_branch(branch_to_switch)
 
 check_branch_to_switch(branch_to_switch, branches)
 
-try:
-    with open(os.path.join(directory_path, ".sccs",  "branches", branch_to_switch, "history", "commit_history.json"), "r", encoding="utf-8", newline="\n") as f:
-        try:
-            commit_history = json.load(f)
-            
-        except Exception as e:
-            print(f"Error parsing commit history for branch '{branch_to_switch}': {e}")
-            sys.exit(1)
-
-except Exception as e: 
-    print(f"Error reading commit history for branch '{branch_to_switch}': {e}")
-    sys.exit(1)
+commit_history = get_commit_history(branch_to_switch)
 
 try:
     latest_commit_on_branch_to_switch = commit_history["history"]["latest_commit"]

--- a/switch.py
+++ b/switch.py
@@ -104,11 +104,16 @@ def check_for_changes(branch, latest_commit_binary_hash, current_document_hash):
 def sanitize_branch(branch_name):
     return sanitize_dirname(branch_name)
 
-def get_commit_history(branch):
+def get_latest_commit(branch):
     try:
         with open(os.path.join(directory_path, ".sccs",  "branches", branch, "history", "commit_history.json"), "r", encoding="utf-8", newline="\n") as f:
             try:
-                return json.load(f)
+                history = json.load(f)
+                try:
+                    return history["history"]["latest_commit"]
+                except KeyError as e:
+                    print(f"Error: Missing key {e} in commit history for branch '{branch}'.")
+                    sys.exit(1)
             except Exception as e:
                 print(f"Error parsing commit history for branch '{branch}': {e}")
                 sys.exit(1)
@@ -130,14 +135,7 @@ branch_to_switch = sanitize_branch(branch_to_switch)
 
 check_branch_to_switch(branch_to_switch, branches)
 
-commit_history = get_commit_history(branch_to_switch)
-
-try:
-    latest_commit_on_branch_to_switch = commit_history["history"]["latest_commit"]
-
-except KeyError as e:
-    print(f"Error: Missing key {e} in commit history for branch '{branch_to_switch}'.")
-    sys.exit(1)
+latest_commit_on_branch_to_switch = get_latest_commit(branch_to_switch)
 
 if not os.path.isfile(os.path.join(directory_path, ".sccs", "objects", "docx", f"{latest_commit_on_branch_to_switch}.docx")):
     print(f"Error: Commit object '{latest_commit_on_branch_to_switch}' not found.")

--- a/switch.py
+++ b/switch.py
@@ -134,6 +134,9 @@ def copy_commit_to_main(commit, branch):
         update_current_branch(branch)
         sys.exit(1)
 
+def print_confirmation(branch_to_switch):
+    print(f"Successfully switched to branch '{branch_to_switch}'.")
+
 branch, branches = get_branch_data()
 
 latest_commit = get_latest_commit(branch)
@@ -156,4 +159,4 @@ update_current_branch(branch_to_switch)
 
 copy_commit_to_main(latest_commit_on_branch_to_switch, branch)
 
-print(f"Successfully switched to branch '{branch_to_switch}'.")
+print_confirmation(branch_to_switch)


### PR DESCRIPTION
# Use Function Block Level Code #89 

This PR focuses on using function level code modules instead of top level code in `switch.py` for the `sccs switch` command to increase readability and testability.

## Switch.py

-  Use function level code modules instead of top level code to increase readability and testability.

## Type of Change

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Refactor

`/gemini review`