### PR TITLE
Feat/#87 feature raise exceptions instead of sysexit1 in utility functions

### DIFF
--- a/commands/branch.py
+++ b/commands/branch.py
@@ -199,25 +199,29 @@ def run_specified_subcommand(subcommand, current_branch, branch_data):
 
 
 def main():
-    if __name__ == "__main__":
+    utils.check_sccs_layout()
 
-        utils.check_sccs_layout()
+    validate_subcommand(get_entered_subcommand(), get_entered_branch_name())
 
-        validate_subcommand(get_entered_subcommand(), get_entered_branch_name())
-
-        run_specified_subcommand(
-            get_entered_subcommand(),
-            utils.get_current_branch(),
-            utils.get_branch_data(),
-        )
-    else:
-        raise exceptions.FileImportedAsModuleError(
-            "This file cannot be run as a module. Please run it as a script."
-        )
+    run_specified_subcommand(
+        get_entered_subcommand(),
+        utils.get_current_branch(),
+        utils.get_branch_data(),
+    )
 
 
-try:
-    main()
-except Exception as e:
-    print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
-    raise exceptions.SCCSException
+if __name__ == "__main__":
+    try:
+        main()
+
+    except exceptions.SCCSException as e:
+        print(f"An error occurred:\n{e}\n")
+        sys.exit(1)
+
+    except Exception as e:
+        print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
+        sys.exit(2)
+else:
+    raise exceptions.FileImportedAsModuleError(
+        "This file cannot be run as a module. Please run it as a script."
+    )

--- a/commands/branch.py
+++ b/commands/branch.py
@@ -208,7 +208,7 @@ def main():
         run_specified_subcommand(
             get_entered_subcommand(),
             utils.get_current_branch(),
-            utils.get_branch_data()
+            utils.get_branch_data(),
         )
     else:
         raise exceptions.FileImportedAsModuleError(

--- a/commands/branch.py
+++ b/commands/branch.py
@@ -76,7 +76,7 @@ def branch_create_subcommand(
         )
     except Exception as e:
         delete_branch_after_error(sanitized_branch_name, cwd=cwd)
-        raise exceptions.FileCopyError(f"Error copying branch '{current_branch}': {e}")
+        raise exceptions.FileCopyError from e
 
     try:
         with open(
@@ -89,9 +89,7 @@ def branch_create_subcommand(
     # Clean up the created directory before raising
     except Exception as e:
         delete_branch_after_error(sanitized_branch_name, cwd=cwd)
-        raise exceptions.BranchCreationError(
-            f"Error creating branch '{sanitized_branch_name}': {e}"
-        )
+        raise exceptions.BranchCreationError from e
 
     print(
         f"Branch '{sanitized_branch_name}' was created from branch '{current_branch}', "
@@ -145,14 +143,15 @@ def branch_delete_subcommand(
             json.dump(branch_data, current_branch_file, indent=4)
 
     except Exception as e:
-        raise exceptions.UpdatingMetadataError(f"Error updating branch data: {e}")
+        raise exceptions.UpdatingMetadataError from e
 
     try:
         shutil.rmtree(branch_path)
 
     except Exception as e:
-        print(f"Error deleting branch '{sanitized_branch_name}': {e}")
         rollback_changes_after_failure(current_branch_path, branch_data=branch_data)
+        raise exceptions.BranchDeletionError from e
+        
 
     print(f"Branch '{sanitized_branch_name}' was deleted.")
 
@@ -175,10 +174,7 @@ def rollback_changes_after_failure(current_branch_path, branch_data=None):
             json.dump(branch_data, current_branch_file, indent=4)
 
     except Exception as e:
-        raise exceptions.UpdatingMetadataError(
-            f"Error updating branch data after failed deletion: {e}. The branch "
-            f"'{sanitized_branch_name}' may be in an inconsistent state."
-        )
+        raise exceptions.UpdatingMetadataError from e
 
 
 def branch_list_subcommand(current_branch, branch_data):

--- a/commands/branch.py
+++ b/commands/branch.py
@@ -4,6 +4,8 @@ import shutil
 import sys
 
 import utils
+import exceptions
+
 
 
 def get_entered_subcommand():

--- a/commands/branch.py
+++ b/commands/branch.py
@@ -24,14 +24,14 @@ def validate_subcommand(subcommand, branch_name):
 
     if not subcommand:
         raise exceptions.InvalidSubcommandError(
-            "No subcommand provided. Please use 'create', 'delete', or 'list' along with"
-            " required arguments."
+            "No subcommand provided. Please use 'create', 'delete', or 'list' along "
+            "with required arguments."
         )
 
     if subcommand not in ["create", "delete", "list"]:
         raise exceptions.InvalidSubcommandError(
-            f"Invalid subcommand: {subcommand}. Please use 'create', 'delete', or 'list'"
-            f" along with required arguments."
+            f"Invalid subcommand: {subcommand}. Please use 'create', 'delete', or 'list"
+            f"' along with required arguments."
         )
 
     if subcommand in ["create", "delete"]:
@@ -208,7 +208,7 @@ def main():
         run_specified_subcommand(
             get_entered_subcommand(),
             utils.get_current_branch(),
-            utils.get_branch_data(),
+            utils.get_branch_data()
         )
     else:
         raise exceptions.FileImportedAsModuleError(

--- a/commands/branch.py
+++ b/commands/branch.py
@@ -56,10 +56,14 @@ def branch_create_subcommand(
     if os.path.isdir(os.path.join(cwd, ".sccs", "branches", sanitized_branch_name)):
         raise exceptions.InvalidArgumentError(f"Branch '{sanitized_branch_name}' already exists.")
 
-    shutil.copytree(
-        os.path.join(cwd, ".sccs", "branches", current_branch),
-        os.path.join(cwd, ".sccs", "branches", sanitized_branch_name),
-    )
+    try:
+        shutil.copytree(
+            os.path.join(cwd, ".sccs", "branches", current_branch),
+            os.path.join(cwd, ".sccs", "branches", sanitized_branch_name),
+        )
+    except Exception as e:
+        delete_branch_after_error(sanitized_branch_name, cwd=cwd)
+        raise exceptions.FileCopyError(f"Error copying branch '{current_branch}': {e}")
 
     try:
         with open(
@@ -69,13 +73,24 @@ def branch_create_subcommand(
             branch_data["current_branch"] = sanitized_branch_name
             json.dump(branch_data, current_branch_file, indent=4)
 
+    # Clean up the created directory before raising
     except Exception as e:
+        delete_branch_after_error(sanitized_branch_name, cwd=cwd)
         raise exceptions.BranchCreationError(f"Error creating branch '{sanitized_branch_name}': {e}")
 
     print(
         f"Branch '{sanitized_branch_name}' was created from branch '{current_branch}', "
         f"and is now the current branch."
     )
+
+
+def delete_branch_after_error(branch_name, cwd=None):
+    if cwd is None:
+        cwd = utils.working_directory_path
+
+    branch_path = os.path.join(cwd, ".sccs", "branches", branch_name)
+    if os.path.isdir(branch_path):
+        shutil.rmtree(branch_path)   
 
 
 def branch_delete_subcommand(

--- a/commands/branch.py
+++ b/commands/branch.py
@@ -197,13 +197,23 @@ def run_specified_subcommand(subcommand, current_branch, branch_data):
     elif subcommand == "list":
         branch_list_subcommand(current_branch, branch_data)
 
+def main():
+    if __name__ == "__main__":
 
-if __name__ == "__main__":
+        utils.check_sccs_layout()
 
-    utils.check_sccs_layout()
+        validate_subcommand(get_entered_subcommand(), get_entered_branch_name())
 
-    validate_subcommand(get_entered_subcommand(), get_entered_branch_name())
+        run_specified_subcommand(
+            get_entered_subcommand(), utils.get_current_branch(), utils.get_branch_data()
+        )
+    else:
+        raise exceptions.FileImportedAsModuleError(
+            "This file cannot be run as a module. Please run it as a script."
+        )
 
-    run_specified_subcommand(
-        get_entered_subcommand(), utils.get_current_branch(), utils.get_branch_data()
-    )
+try:
+    main()
+except Exception as e: 
+    print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
+    raise exceptions.SCCSException

--- a/commands/branch.py
+++ b/commands/branch.py
@@ -24,12 +24,14 @@ def validate_subcommand(subcommand, branch_name):
 
     if not subcommand:
         raise exceptions.InvalidSubcommandError(
-            "No subcommand provided. Please use 'create','delete', or 'list' along with required arguments."
+            "No subcommand provided. Please use 'create','delete', or 'list' along with"
+            " required arguments."
         )
 
     if subcommand not in ["create", "delete", "list"]:
         raise exceptions.InvalidSubcommandError(
-            f"Invalid subcommand: {subcommand}. Please use 'create','delete', or 'list' along with required arguments."
+            f"Invalid subcommand: {subcommand}. Please use 'create','delete', or 'list'"
+            f" along with required arguments."
         )
 
     if subcommand in ["create", "delete"]:
@@ -174,7 +176,8 @@ def rollback_changes_after_failure(current_branch_path, branch_data=None):
 
     except Exception as e:
         raise exceptions.UpdatingMetadataError(
-            f"Error updating branch data after failed deletion: {e}. The branch '{sanitized_branch_name}' may be in an inconsistent state."
+            f"Error updating branch data after failed deletion: {e}. The branch "
+            f"'{sanitized_branch_name}' may be in an inconsistent state."
         )
 
 

--- a/commands/branch.py
+++ b/commands/branch.py
@@ -151,7 +151,6 @@ def branch_delete_subcommand(
     except Exception as e:
         rollback_changes_after_failure(current_branch_path, branch_data=branch_data)
         raise exceptions.BranchDeletionError from e
-        
 
     print(f"Branch '{sanitized_branch_name}' was deleted.")
 

--- a/commands/branch.py
+++ b/commands/branch.py
@@ -60,12 +60,12 @@ def branch_create_subcommand(
         )
 
     if sanitized_branch_name in branch_data["branches"]:
-        raise exceptions.InvalidArgumentError(
+        raise exceptions.BranchAlreadyExistsError(
             f"Branch '{sanitized_branch_name}' already exists."
         )
 
     if os.path.isdir(os.path.join(cwd, ".sccs", "branches", sanitized_branch_name)):
-        raise exceptions.InvalidArgumentError(
+        raise exceptions.BranchAlreadyExistsError(
             f"Branch '{sanitized_branch_name}' already exists."
         )
 
@@ -126,7 +126,7 @@ def branch_delete_subcommand(
         )
 
     if not os.path.exists(branch_path):
-        raise exceptions.BranchDeletionError(
+        raise exceptions.BranchNotFoundError(
             f"Branch '{sanitized_branch_name}' does not exist."
         )
 

--- a/commands/branch.py
+++ b/commands/branch.py
@@ -197,6 +197,7 @@ def run_specified_subcommand(subcommand, current_branch, branch_data):
     elif subcommand == "list":
         branch_list_subcommand(current_branch, branch_data)
 
+
 def main():
     if __name__ == "__main__":
 
@@ -205,15 +206,18 @@ def main():
         validate_subcommand(get_entered_subcommand(), get_entered_branch_name())
 
         run_specified_subcommand(
-            get_entered_subcommand(), utils.get_current_branch(), utils.get_branch_data()
+            get_entered_subcommand(),
+            utils.get_current_branch(),
+            utils.get_branch_data(),
         )
     else:
         raise exceptions.FileImportedAsModuleError(
             "This file cannot be run as a module. Please run it as a script."
         )
 
+
 try:
     main()
-except Exception as e: 
+except Exception as e:
     print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
     raise exceptions.SCCSException

--- a/commands/branch.py
+++ b/commands/branch.py
@@ -24,25 +24,14 @@ def validate_subcommand(subcommand, branch_name):
     """Validate the subcommand entered by the user."""
 
     if not subcommand:
-        print(
-            "No subcommand provided. Please use 'create', 'delete', or 'list' along "
-            "with required arguments."
-        )
-        sys.exit(1)
+        raise exceptions.InvalidSubcommandError("No subcommand provided. Please use 'create','delete', or 'list' along with required arguments.")
 
     if subcommand not in ["create", "delete", "list"]:
-        print(f"Unknown subcommand: {subcommand}")
-        print(
-            "Invalid subcommand. Please use 'create', 'delete', or 'list' along with "
-            "required arguments."
-        )
-        sys.exit(1)
+        raise exceptions.InvalidSubcommandError(f"Invalid subcommand: {subcommand}. Please use 'create','delete', or 'list' along with required arguments.")
 
     if subcommand in ["create", "delete"]:
         if not branch_name:
-            print("No branch name provided. Please specify a branch name.")
-            sys.exit(1)
-
+            raise exceptions.InvalidArgumentError("No branch name provided. Please specify a branch name.")
 
 def branch_create_subcommand(
     current_branch, branch_data, cwd=None, current_branch_path=None
@@ -58,19 +47,14 @@ def branch_create_subcommand(
     sanitized_branch_name = utils.clean_directory_name(get_entered_branch_name())
 
     if not sanitized_branch_name:
-        print("Invalid branch name. Please provide a valid branch name.")
-        sys.exit(1)
+        raise exceptions.InvalidArgumentError("Invalid branch name. Please provide a valid branch name.")
+
 
     if sanitized_branch_name in branch_data["branches"]:
-        print(f"Branch '{sanitized_branch_name}' already exists.")
-        sys.exit(1)
+        raise exceptions.InvalidArgumentError(f"Branch '{sanitized_branch_name}' already exists.")
 
     if os.path.isdir(os.path.join(cwd, ".sccs", "branches", sanitized_branch_name)):
-        print(
-            f"Branch '{sanitized_branch_name}' already exists, or a directory with the "
-            f"same name exists."
-        )
-        sys.exit(1)
+        raise exceptions.InvalidArgumentError(f"Branch '{sanitized_branch_name}' already exists.")
 
     shutil.copytree(
         os.path.join(cwd, ".sccs", "branches", current_branch),
@@ -86,8 +70,7 @@ def branch_create_subcommand(
             json.dump(branch_data, current_branch_file, indent=4)
 
     except Exception as e:
-        print(f"Error creating branch '{sanitized_branch_name}': {e}")
-        sys.exit(1)
+        raise exceptions.BranchCreationError(f"Error creating branch '{sanitized_branch_name}': {e}")
 
     print(
         f"Branch '{sanitized_branch_name}' was created from branch '{current_branch}', "
@@ -110,16 +93,17 @@ def branch_delete_subcommand(
     branch_path = os.path.join(cwd, ".sccs", "branches", sanitized_branch_name)
 
     if sanitized_branch_name == current_branch:
-        print("Cannot delete the current branch.")
-        sys.exit(1)
+        raise exceptions.BranchDeletionError(
+            "Cannot delete the current branch. Please switch to another branch first."
+        )
 
     if not os.path.exists(branch_path):
-        print(f"Branch '{sanitized_branch_name}' does not exist.")
-        sys.exit(1)
+        raise exceptions.BranchDeletionError(
+            f"Branch '{sanitized_branch_name}' does not exist."
+        )
 
     if not sanitized_branch_name in branch_data["branches"]:
-        print(f"Branch '{sanitized_branch_name}' does not exist in branch data.")
-        sys.exit(1)
+        raise exceptions.BranchMissingFromMetadataError(f"Branch '{sanitized_branch_name}' does not exist in branch data.")
 
     try:
         with open(
@@ -129,8 +113,7 @@ def branch_delete_subcommand(
             json.dump(branch_data, current_branch_file, indent=4)
 
     except Exception as e:
-        print(f"Error updating branch data: {e}")
-        sys.exit(1)
+        raise exceptions.UpdatingMetadataError(f"Error updating branch data: {e}")
 
     try:
         shutil.rmtree(branch_path)
@@ -160,12 +143,9 @@ def rollback_changes_after_failure(current_branch_path, branch_data=None):
             json.dump(branch_data, current_branch_file, indent=4)
 
     except Exception as e:
-        print(
-            f"Error updating branch data after failed deletion: {e}\nThe branch '"
-            f"{sanitized_branch_name}' may be in an inconsistent state."
+        raise exceptions.UpdatingMetadataError(
+            f"Error updating branch data after failed deletion: {e}. The branch '{sanitized_branch_name}' may be in an inconsistent state."
         )
-        sys.exit(1)
-
 
 def branch_list_subcommand(current_branch, branch_data):
     """List all branches."""

--- a/commands/branch.py
+++ b/commands/branch.py
@@ -3,9 +3,8 @@ import os
 import shutil
 import sys
 
-import utils
 import exceptions
-
+import utils
 
 
 def get_entered_subcommand():
@@ -24,14 +23,21 @@ def validate_subcommand(subcommand, branch_name):
     """Validate the subcommand entered by the user."""
 
     if not subcommand:
-        raise exceptions.InvalidSubcommandError("No subcommand provided. Please use 'create','delete', or 'list' along with required arguments.")
+        raise exceptions.InvalidSubcommandError(
+            "No subcommand provided. Please use 'create','delete', or 'list' along with required arguments."
+        )
 
     if subcommand not in ["create", "delete", "list"]:
-        raise exceptions.InvalidSubcommandError(f"Invalid subcommand: {subcommand}. Please use 'create','delete', or 'list' along with required arguments.")
+        raise exceptions.InvalidSubcommandError(
+            f"Invalid subcommand: {subcommand}. Please use 'create','delete', or 'list' along with required arguments."
+        )
 
     if subcommand in ["create", "delete"]:
         if not branch_name:
-            raise exceptions.InvalidArgumentError("No branch name provided. Please specify a branch name.")
+            raise exceptions.InvalidArgumentError(
+                "No branch name provided. Please specify a branch name."
+            )
+
 
 def branch_create_subcommand(
     current_branch, branch_data, cwd=None, current_branch_path=None
@@ -47,14 +53,19 @@ def branch_create_subcommand(
     sanitized_branch_name = utils.clean_directory_name(get_entered_branch_name())
 
     if not sanitized_branch_name:
-        raise exceptions.InvalidArgumentError("Invalid branch name. Please provide a valid branch name.")
-
+        raise exceptions.InvalidArgumentError(
+            "Invalid branch name. Please provide a valid branch name."
+        )
 
     if sanitized_branch_name in branch_data["branches"]:
-        raise exceptions.InvalidArgumentError(f"Branch '{sanitized_branch_name}' already exists.")
+        raise exceptions.InvalidArgumentError(
+            f"Branch '{sanitized_branch_name}' already exists."
+        )
 
     if os.path.isdir(os.path.join(cwd, ".sccs", "branches", sanitized_branch_name)):
-        raise exceptions.InvalidArgumentError(f"Branch '{sanitized_branch_name}' already exists.")
+        raise exceptions.InvalidArgumentError(
+            f"Branch '{sanitized_branch_name}' already exists."
+        )
 
     try:
         shutil.copytree(
@@ -76,7 +87,9 @@ def branch_create_subcommand(
     # Clean up the created directory before raising
     except Exception as e:
         delete_branch_after_error(sanitized_branch_name, cwd=cwd)
-        raise exceptions.BranchCreationError(f"Error creating branch '{sanitized_branch_name}': {e}")
+        raise exceptions.BranchCreationError(
+            f"Error creating branch '{sanitized_branch_name}': {e}"
+        )
 
     print(
         f"Branch '{sanitized_branch_name}' was created from branch '{current_branch}', "
@@ -90,7 +103,7 @@ def delete_branch_after_error(branch_name, cwd=None):
 
     branch_path = os.path.join(cwd, ".sccs", "branches", branch_name)
     if os.path.isdir(branch_path):
-        shutil.rmtree(branch_path)   
+        shutil.rmtree(branch_path)
 
 
 def branch_delete_subcommand(
@@ -118,7 +131,9 @@ def branch_delete_subcommand(
         )
 
     if not sanitized_branch_name in branch_data["branches"]:
-        raise exceptions.BranchMissingFromMetadataError(f"Branch '{sanitized_branch_name}' does not exist in branch data.")
+        raise exceptions.BranchMissingFromMetadataError(
+            f"Branch '{sanitized_branch_name}' does not exist in branch data."
+        )
 
     try:
         with open(
@@ -161,6 +176,7 @@ def rollback_changes_after_failure(current_branch_path, branch_data=None):
         raise exceptions.UpdatingMetadataError(
             f"Error updating branch data after failed deletion: {e}. The branch '{sanitized_branch_name}' may be in an inconsistent state."
         )
+
 
 def branch_list_subcommand(current_branch, branch_data):
     """List all branches."""

--- a/commands/branch.py
+++ b/commands/branch.py
@@ -24,13 +24,13 @@ def validate_subcommand(subcommand, branch_name):
 
     if not subcommand:
         raise exceptions.InvalidSubcommandError(
-            "No subcommand provided. Please use 'create','delete', or 'list' along with"
+            "No subcommand provided. Please use 'create', 'delete', or 'list' along with"
             " required arguments."
         )
 
     if subcommand not in ["create", "delete", "list"]:
         raise exceptions.InvalidSubcommandError(
-            f"Invalid subcommand: {subcommand}. Please use 'create','delete', or 'list'"
+            f"Invalid subcommand: {subcommand}. Please use 'create', 'delete', or 'list'"
             f" along with required arguments."
         )
 

--- a/commands/commit.py
+++ b/commands/commit.py
@@ -74,7 +74,7 @@ def get_commit_history():
             history = json.load(history_file)
 
     except Exception as e:
-        raise exceptions.FileOpenError(f"Error retrieving JSON from history file: {e}")
+        raise exceptions.FileOpenError from e
 
     return history
 
@@ -190,9 +190,7 @@ def update_commit_messages(sha_hash, commit_message, cwd=None):
         try:
             messages = json.load(commit_messages_file)
         except Exception as e:
-            raise exceptions.FileOpenError(
-                f"Error retrieving JSON from commit messages file: {e}"
-            )
+            raise exceptions.FileOpenError from e
 
     messages[f"{sha_hash}"] = f"{commit_message}"
 
@@ -229,9 +227,7 @@ def update_commit_binary_hash_history(
             commit_file_hash = json.load(f)
 
     except Exception as e:
-        raise exceptions.FileOpenError(
-            f"Error retrieving JSON from commit file hash file: {e}"
-        )
+        raise exceptions.FileOpenError from e
 
     commit_file_hash[f"{sha_hash}"] = hash_docx_binary
 
@@ -257,13 +253,13 @@ def atomically_update_history(update_dict):
             ) as f:
                 json.dump(value, f)
         except Exception as e:
-            raise exceptions.TemporaryFileError(f"Error opening temporary file: {e}")
+            raise exceptions.TemporaryFileError from e
 
     for key, value in update_dict.items():
         try:
             os.replace(f"{Path(key).with_suffix('.tmp')}", f"{Path(key)}")
         except Exception as e:
-            raise exceptions.TemporaryFileError(f"Error replacing temporary file: {e}")
+            raise exceptions.TemporaryFileError from e
 
 
 def print_commit_confirmation_message(sha_hash):

--- a/commands/commit.py
+++ b/commands/commit.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from pathlib import Path
 
 import utils
+import exceptions
 
 
 def get_key_from_config(key, cwd=None):

--- a/commands/commit.py
+++ b/commands/commit.py
@@ -269,63 +269,65 @@ def print_commit_confirmation_message(sha_hash):
 
 
 def main():
-    if __name__ == "__main__":
-        utils.check_sccs_layout()
+    utils.check_sccs_layout()
 
-        name = get_key_from_config("name")
+    name = get_key_from_config("name")
 
-        email = get_key_from_config("email")
+    email = get_key_from_config("email")
 
-        docx_html = utils.convert_docx_to_html()
+    docx_html = utils.convert_docx_to_html()
 
-        commit_message = get_commit_message()
+    commit_message = get_commit_message()
 
-        timestamp = get_timestamp()
+    timestamp = get_timestamp()
 
-        history = get_commit_history()
+    history = get_commit_history()
 
-        parent_hash = get_parent_hash(history)
+    parent_hash = get_parent_hash(history)
 
-        sha_hash = generate_commit_hash(
-            timestamp, commit_message, name, email, parent_hash
-        )
+    sha_hash = generate_commit_hash(timestamp, commit_message, name, email, parent_hash)
 
-        copy_docx_to_objects(sha_hash)
+    copy_docx_to_objects(sha_hash)
 
-        write_diff_html(sha_hash, docx_html)
+    write_diff_html(sha_hash, docx_html)
 
-        write_view_html(sha_hash, docx_html)
+    write_view_html(sha_hash, docx_html)
 
-        updated_commit_log_history = update_commit_log_history(
-            history, sha_hash, timestamp, name, email, commit_message
-        )
+    updated_commit_log_history = update_commit_log_history(
+        history, sha_hash, timestamp, name, email, commit_message
+    )
 
-        current_branch_binary_hash = utils.hash_current_docx_binary()
+    current_branch_binary_hash = utils.hash_current_docx_binary()
 
-        updated_commit_binary_hash_history = update_commit_binary_hash_history(
-            sha_hash, current_branch_binary_hash
-        )
+    updated_commit_binary_hash_history = update_commit_binary_hash_history(
+        sha_hash, current_branch_binary_hash
+    )
 
-        updated_commit_messages = update_commit_messages(sha_hash, commit_message)
+    updated_commit_messages = update_commit_messages(sha_hash, commit_message)
 
-        combined_history_update_dicts = combine_update_dicts(
-            updated_commit_log_history,
-            updated_commit_binary_hash_history,
-            updated_commit_messages,
-        )
+    combined_history_update_dicts = combine_update_dicts(
+        updated_commit_log_history,
+        updated_commit_binary_hash_history,
+        updated_commit_messages,
+    )
 
-        atomically_update_history(combined_history_update_dicts)
+    atomically_update_history(combined_history_update_dicts)
 
-        print_commit_confirmation_message(sha_hash)
-
-    else:
-        raise exceptions.FileImportedAsModuleError(
-            "This file cannot be run as a module. Please run it as a script."
-        )
+    print_commit_confirmation_message(sha_hash)
 
 
-try:
-    main()
-except Exception as e:
-    print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
-    raise exceptions.SCCSException
+if __name__ == "__main__":
+    try:
+        main()
+
+    except exceptions.SCCSException as e:
+        print(f"An error occurred:\n{e}\n")
+        sys.exit(1)
+
+    except Exception as e:
+        print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
+        sys.exit(2)
+else:
+    raise exceptions.FileImportedAsModuleError(
+        "This file cannot be run as a module. Please run it as a script."
+    )

--- a/commands/commit.py
+++ b/commands/commit.py
@@ -19,11 +19,7 @@ def get_key_from_config(key, cwd=None):
     config_path = os.path.join(cwd, ".sccs", "config", "config.json")
 
     if not Path(config_path).is_file():
-        print(
-            "Configuration file not found. Please run 'sccs init <file_path>' to "
-            "initialize SCCS for this file."
-        )
-        sys.exit(1)
+        raise FileNotFoundError("Configuration file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     with open(config_path, "r", encoding="utf-8", newline="\n") as config_file:
         config = json.load(config_file)
@@ -37,16 +33,14 @@ def get_commit_message():
     commit_message = input("Enter commit message: ").strip()
 
     if commit_message == "":
-        print("Commit message cannot be empty.")
-        sys.exit(1)
-    return commit_message
+        raise exceptions.EmptyCommitMessageError("Commit message cannot be empty.")
 
+    return commit_message
 
 def get_timestamp():
     """Retrieve the current timestamp."""
 
     return datetime.now().isoformat()
-
 
 def get_history_path(cwd=None, current_branch=None):
     """Retrieve the path to the commit history file."""
@@ -65,19 +59,14 @@ def get_commit_history():
 
     history_path = get_history_path()
     if not Path(history_path).is_file():
-        print(
-            "History file not found. Please run 'sccs init <file_path>' to initialize "
-            "SCCS for this file."
-        )
-        sys.exit(1)
+        raise FileNotFoundError("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     try:
         with open(history_path, "r", encoding="utf-8", newline="\n") as history_file:
             history = json.load(history_file)
 
     except Exception as e:
-        print(f"Error retrieving JSON from history file: {e}")
-        sys.exit(1)
+        raise exceptions.FileOpenError(f"Error retrieving JSON from history file: {e}")
 
     return history
 
@@ -148,12 +137,8 @@ def update_commit_log_history(
     # Check if history file exists
     commit_history_path = get_history_path()
     if not os.path.isfile(commit_history_path):
-        print(
-            "History file not found. Please run 'sccs init <file_path>' to initialize "
-            "SCCS for this file."
-        )
-        sys.exit(1)
-
+        raise FileNotFoundError("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+    
     # Update history
     history["history"]["latest_commit"] = f"{sha_hash}"
     history["history"]["latest_commit_number"] = (
@@ -183,11 +168,7 @@ def update_commit_messages(sha_hash, commit_message, cwd=None):
     )
 
     if not Path(commit_messages_path).is_file():
-        print(
-            "Commit messages file not found. Please run 'sccs init <file_path>' to "
-            "initialize SCCS for this file."
-        )
-        sys.exit(1)
+        raise FileNotFoundError("Commit messages file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     with open(
         commit_messages_path, "r", encoding="utf-8", newline="\n"
@@ -195,8 +176,7 @@ def update_commit_messages(sha_hash, commit_message, cwd=None):
         try:
             messages = json.load(commit_messages_file)
         except Exception as e:
-            print(f"Error reading commit messages: {e}")
-            sys.exit(1)
+            raise exceptions.FileOpenError(f"Error retrieving JSON from commit messages file: {e}")
 
     messages[f"{sha_hash}"] = f"{commit_message}"
 
@@ -223,19 +203,16 @@ def update_commit_binary_hash_history(
         "commit_file_hash.json",
     )
     if not Path(commit_file_hash_path).is_file():
-        print(
-            "Commit file hash not found. Please run 'sccs init <file_path>' to "
-            "initialize SCCS for this file."
-        )
-        sys.exit(1)
+        raise FileNotFoundError("Commit file hash not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     try:
         with open(commit_file_hash_path, "r", encoding="utf-8", newline="\n") as f:
             commit_file_hash = json.load(f)
 
-    except (json.JSONDecodeError, KeyError, TypeError, OSError) as e:
-        print(f"Error loading commit file hash: {e}")
-        sys.exit(1)
+    except Exception as e:
+        raise exceptions.FileOpenError(f"Error retrieving JSON from commit file hash file: {e}")
+
+
     commit_file_hash[f"{sha_hash}"] = hash_docx_binary
 
     return {commit_file_hash_path: commit_file_hash}
@@ -260,15 +237,13 @@ def atomically_update_history(update_dict):
             ) as f:
                 json.dump(value, f)
         except Exception as e:
-            print(f"Error opening temporary file: {e}")
-            sys.exit(1)
+            raise exceptions.TemporaryFileError(f"Error opening temporary file: {e}")
+
     for key, value in update_dict.items():
         try:
             os.replace(f"{Path(key).with_suffix('.tmp')}", f"{Path(key)}")
         except Exception as e:
-            print(f"Error replacing temporary file: {e}")
-            sys.exit(1)
-
+            raise exceptions.TemporaryFileError(f"Error replacing temporary file: {e}")
 
 def print_commit_confirmation_message(sha_hash):
     """Print a confirmation message for the commit."""

--- a/commands/commit.py
+++ b/commands/commit.py
@@ -20,7 +20,8 @@ def get_key_from_config(key, cwd=None):
 
     if not Path(config_path).is_file():
         raise FileNotFoundError(
-            "Configuration file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "Configuration file not found. Please run 'sccs init <file_path>' to "
+            "initialize SCCS for this file."
         )
 
     with open(config_path, "r", encoding="utf-8", newline="\n") as config_file:
@@ -64,7 +65,8 @@ def get_commit_history():
     history_path = get_history_path()
     if not Path(history_path).is_file():
         raise FileNotFoundError(
-            "History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "History file not found. Please run 'sccs init <file_path>' to initialize "
+            "SCCS for this file."
         )
 
     try:
@@ -144,7 +146,8 @@ def update_commit_log_history(
     commit_history_path = get_history_path()
     if not os.path.isfile(commit_history_path):
         raise FileNotFoundError(
-            "History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "History file not found. Please run 'sccs init <file_path>' to initialize "
+            "SCCS for this file."
         )
 
     # Update history
@@ -177,7 +180,8 @@ def update_commit_messages(sha_hash, commit_message, cwd=None):
 
     if not Path(commit_messages_path).is_file():
         raise FileNotFoundError(
-            "Commit messages file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "Commit messages file not found. Please run 'sccs init <file_path>' to "
+            "initialize SCCS for this file."
         )
 
     with open(
@@ -216,7 +220,8 @@ def update_commit_binary_hash_history(
     )
     if not Path(commit_file_hash_path).is_file():
         raise FileNotFoundError(
-            "Commit file hash not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "Commit file hash not found. Please run 'sccs init <file_path>' to "
+            f"initialize SCCS for this file."
         )
 
     try:

--- a/commands/commit.py
+++ b/commands/commit.py
@@ -267,50 +267,63 @@ def print_commit_confirmation_message(sha_hash):
 
     print(f"Commit {sha_hash} created successfully.")
 
+def main():
+    if __name__ == "__main__":
+        utils.check_sccs_layout()
 
-if __name__ == "__main__":
-    utils.check_sccs_layout()
+        name = get_key_from_config("name")
 
-    name = get_key_from_config("name")
+        email = get_key_from_config("email")
 
-    email = get_key_from_config("email")
+        docx_html = utils.convert_docx_to_html()
 
-    docx_html = utils.convert_docx_to_html()
+        commit_message = get_commit_message()
 
-    commit_message = get_commit_message()
+        timestamp = get_timestamp()
 
-    timestamp = get_timestamp()
+        history = get_commit_history()
 
-    history = get_commit_history()
+        parent_hash = get_parent_hash(history)
 
-    parent_hash = get_parent_hash(history)
+        sha_hash = generate_commit_hash(
+            timestamp, commit_message, name, email, parent_hash
+        )
 
-    sha_hash = generate_commit_hash(timestamp, commit_message, name, email, parent_hash)
+        copy_docx_to_objects(sha_hash)
 
-    copy_docx_to_objects(sha_hash)
+        write_diff_html(sha_hash, docx_html)
 
-    write_diff_html(sha_hash, docx_html)
+        write_view_html(sha_hash, docx_html)
 
-    write_view_html(sha_hash, docx_html)
+        updated_commit_log_history = update_commit_log_history(
+            history, sha_hash, timestamp, name, email, commit_message
+        )
 
-    updated_commit_log_history = update_commit_log_history(
-        history, sha_hash, timestamp, name, email, commit_message
-    )
+        current_branch_binary_hash = utils.hash_current_docx_binary()
 
-    current_branch_binary_hash = utils.hash_current_docx_binary()
+        updated_commit_binary_hash_history = update_commit_binary_hash_history(
+            sha_hash, current_branch_binary_hash
+        )
 
-    updated_commit_binary_hash_history = update_commit_binary_hash_history(
-        sha_hash, current_branch_binary_hash
-    )
+        updated_commit_messages = update_commit_messages(sha_hash, commit_message)
 
-    updated_commit_messages = update_commit_messages(sha_hash, commit_message)
+        combined_history_update_dicts = combine_update_dicts(
+            updated_commit_log_history,
+            updated_commit_binary_hash_history,
+            updated_commit_messages,
+        )
 
-    combined_history_update_dicts = combine_update_dicts(
-        updated_commit_log_history,
-        updated_commit_binary_hash_history,
-        updated_commit_messages,
-    )
+        atomically_update_history(combined_history_update_dicts)
 
-    atomically_update_history(combined_history_update_dicts)
+        print_commit_confirmation_message(sha_hash)
+    
+    else:
+        raise exceptions.FileImportedAsModuleError(
+            "This file cannot be run as a module. Please run it as a script."
+        )
 
-    print_commit_confirmation_message(sha_hash)
+try:
+    main()
+except Exception as e:
+    print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
+    raise exceptions.SCCSException

--- a/commands/commit.py
+++ b/commands/commit.py
@@ -267,6 +267,7 @@ def print_commit_confirmation_message(sha_hash):
 
     print(f"Commit {sha_hash} created successfully.")
 
+
 def main():
     if __name__ == "__main__":
         utils.check_sccs_layout()
@@ -316,11 +317,12 @@ def main():
         atomically_update_history(combined_history_update_dicts)
 
         print_commit_confirmation_message(sha_hash)
-    
+
     else:
         raise exceptions.FileImportedAsModuleError(
             "This file cannot be run as a module. Please run it as a script."
         )
+
 
 try:
     main()

--- a/commands/commit.py
+++ b/commands/commit.py
@@ -6,8 +6,8 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
-import utils
 import exceptions
+import utils
 
 
 def get_key_from_config(key, cwd=None):
@@ -19,7 +19,9 @@ def get_key_from_config(key, cwd=None):
     config_path = os.path.join(cwd, ".sccs", "config", "config.json")
 
     if not Path(config_path).is_file():
-        raise FileNotFoundError("Configuration file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise FileNotFoundError(
+            "Configuration file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
 
     with open(config_path, "r", encoding="utf-8", newline="\n") as config_file:
         config = json.load(config_file)
@@ -37,10 +39,12 @@ def get_commit_message():
 
     return commit_message
 
+
 def get_timestamp():
     """Retrieve the current timestamp."""
 
     return datetime.now().isoformat()
+
 
 def get_history_path(cwd=None, current_branch=None):
     """Retrieve the path to the commit history file."""
@@ -59,7 +63,9 @@ def get_commit_history():
 
     history_path = get_history_path()
     if not Path(history_path).is_file():
-        raise FileNotFoundError("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise FileNotFoundError(
+            "History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
 
     try:
         with open(history_path, "r", encoding="utf-8", newline="\n") as history_file:
@@ -137,8 +143,10 @@ def update_commit_log_history(
     # Check if history file exists
     commit_history_path = get_history_path()
     if not os.path.isfile(commit_history_path):
-        raise FileNotFoundError("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
-    
+        raise FileNotFoundError(
+            "History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
+
     # Update history
     history["history"]["latest_commit"] = f"{sha_hash}"
     history["history"]["latest_commit_number"] = (
@@ -168,7 +176,9 @@ def update_commit_messages(sha_hash, commit_message, cwd=None):
     )
 
     if not Path(commit_messages_path).is_file():
-        raise FileNotFoundError("Commit messages file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise FileNotFoundError(
+            "Commit messages file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
 
     with open(
         commit_messages_path, "r", encoding="utf-8", newline="\n"
@@ -176,7 +186,9 @@ def update_commit_messages(sha_hash, commit_message, cwd=None):
         try:
             messages = json.load(commit_messages_file)
         except Exception as e:
-            raise exceptions.FileOpenError(f"Error retrieving JSON from commit messages file: {e}")
+            raise exceptions.FileOpenError(
+                f"Error retrieving JSON from commit messages file: {e}"
+            )
 
     messages[f"{sha_hash}"] = f"{commit_message}"
 
@@ -203,15 +215,18 @@ def update_commit_binary_hash_history(
         "commit_file_hash.json",
     )
     if not Path(commit_file_hash_path).is_file():
-        raise FileNotFoundError("Commit file hash not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise FileNotFoundError(
+            "Commit file hash not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
 
     try:
         with open(commit_file_hash_path, "r", encoding="utf-8", newline="\n") as f:
             commit_file_hash = json.load(f)
 
     except Exception as e:
-        raise exceptions.FileOpenError(f"Error retrieving JSON from commit file hash file: {e}")
-
+        raise exceptions.FileOpenError(
+            f"Error retrieving JSON from commit file hash file: {e}"
+        )
 
     commit_file_hash[f"{sha_hash}"] = hash_docx_binary
 
@@ -244,6 +259,7 @@ def atomically_update_history(update_dict):
             os.replace(f"{Path(key).with_suffix('.tmp')}", f"{Path(key)}")
         except Exception as e:
             raise exceptions.TemporaryFileError(f"Error replacing temporary file: {e}")
+
 
 def print_commit_confirmation_message(sha_hash):
     """Print a confirmation message for the commit."""

--- a/commands/diff.py
+++ b/commands/diff.py
@@ -225,41 +225,44 @@ def write_redline_html_file(redline, filename="redline.html"):
 
 
 def main():
-    if __name__ == "__main__":
+    utils.check_sccs_layout()
 
-        utils.check_sccs_layout()
+    validate_commit(get_entered_commit_to_diff(), utils.current_file_docx_path)
 
-        validate_commit(get_entered_commit_to_diff(), utils.current_file_docx_path)
+    docx_current_version_html = utils.convert_docx_to_html()
 
-        docx_current_version_html = utils.convert_docx_to_html()
+    commit_html = get_commit_html(get_entered_commit_to_diff())
 
-        commit_html = get_commit_html(get_entered_commit_to_diff())
+    bs4_docx_current_version_soup = convert_html_to_soup(docx_current_version_html)
 
-        bs4_docx_current_version_soup = convert_html_to_soup(docx_current_version_html)
+    docx_current_version_list = format_bs4_html_list(bs4_docx_current_version_soup)
 
-        docx_current_version_list = format_bs4_html_list(bs4_docx_current_version_soup)
+    bs4_commit_soup = convert_html_to_soup(commit_html)
+    commit_list = format_bs4_html_list(bs4_commit_soup)
 
-        bs4_commit_soup = convert_html_to_soup(commit_html)
-        commit_list = format_bs4_html_list(bs4_commit_soup)
+    opcodes = get_opcodes(bs4_commit_soup, bs4_docx_current_version_soup)
 
-        opcodes = get_opcodes(bs4_commit_soup, bs4_docx_current_version_soup)
+    base_redline_html = get_redline_html(bs4_commit_soup)
 
-        base_redline_html = get_redline_html(bs4_commit_soup)
+    redline = format_redline_html(
+        base_redline_html, opcodes, commit_list, docx_current_version_list
+    )
 
-        redline = format_redline_html(
-            base_redline_html, opcodes, commit_list, docx_current_version_list
-        )
-
-        write_redline_html_file(redline)
-
-    else:
-        raise exceptions.FileImportedAsModuleError(
-            "This file cannot be run as a module. Please run it as a script."
-        )
+    write_redline_html_file(redline)
 
 
-try:
-    main()
-except Exception as e:
-    print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
-    raise exceptions.SCCSException
+if __name__ == "__main__":
+    try:
+        main()
+
+    except exceptions.SCCSException as e:
+        print(f"An error occurred:\n{e}\n")
+        sys.exit(1)
+
+    except Exception as e:
+        print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
+        sys.exit(2)
+else:
+    raise exceptions.FileImportedAsModuleError(
+        "This file cannot be run as a module. Please run it as a script."
+    )

--- a/commands/diff.py
+++ b/commands/diff.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 
 import utils
+import exceptions
 from bs4 import BeautifulSoup
 
 

--- a/commands/diff.py
+++ b/commands/diff.py
@@ -43,7 +43,7 @@ def get_commit_html(commit_path):
         with open(commit_path, "r", encoding="utf-8", newline="\n") as f:
             commit_html = f.read()
     except Exception as e:
-        raise exceptions.FileOpenError(f"Error reading commit file: {e}")
+        raise exceptions.FileOpenError from e
     return commit_html
 
 

--- a/commands/diff.py
+++ b/commands/diff.py
@@ -38,7 +38,7 @@ def get_commit_html(commit_path):
         with open(commit_path, "r", encoding="utf-8", newline="\n") as f:
             commit_html = f.read()
     except Exception as e:
-        raise exceptions.FileOpenError
+        raise exceptions.FileOpenError(f"Error reading commit file: {e}")
     return commit_html
 
 

--- a/commands/diff.py
+++ b/commands/diff.py
@@ -18,25 +18,17 @@ def validate_commit(commit_to_diff, docx_current_version):
     """Validate the commit file and current docx file paths."""
 
     if not commit_to_diff:
-        print("No commit file specified.")
-        sys.exit(1)
+        raise exceptions.InvalidArgumentError("No commit file path provided.")
 
     if not Path(commit_to_diff).is_file():
-        print("Commit file not found. Please provide a valid commit file path.")
-        sys.exit(1)
-
+            raise FileNotFoundError("Commit file not found. Please provide a valid commit file path.")
+    
     if Path(commit_to_diff).suffix.lower() != ".html":
-        print(
-            "Commit file is not a .html file. Please provide a valid .html commit file"
-        )
-        sys.exit(1)
+        raise exceptions.InvalidArgumentError("Commit file is not a .html file. Please provide a valid .html commit file")
 
     if not Path(docx_current_version).is_file():
-        print(
-            "Docx file not found. Re-initialize SCCS for this file with 'sccs init"
-            "<file_path>'"
-        )
-        sys.exit(1)
+        raise FileNotFoundError("Docx file not found. Please provide a valid docx file path.")
+
 
 
 def get_commit_html(commit_path):
@@ -46,8 +38,7 @@ def get_commit_html(commit_path):
         with open(commit_path, "r", encoding="utf-8", newline="\n") as f:
             commit_html = f.read()
     except Exception as e:
-        print(f"Error reading commit file: {e}")
-        sys.exit(1)
+        raise exceptions.FileOpenError
     return commit_html
 
 

--- a/commands/diff.py
+++ b/commands/diff.py
@@ -223,6 +223,7 @@ def write_redline_html_file(redline, filename="redline.html"):
     with open(filename, "w", encoding="utf-8", newline="\n") as f:
         f.write(utils.wrap_html(str(strip_number_attribute(redline))))
 
+
 def main():
     if __name__ == "__main__":
 
@@ -255,10 +256,10 @@ def main():
         raise exceptions.FileImportedAsModuleError(
             "This file cannot be run as a module. Please run it as a script."
         )
-    
+
+
 try:
     main()
-except Exception as e: 
+except Exception as e:
     print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
     raise exceptions.SCCSException
-

--- a/commands/diff.py
+++ b/commands/diff.py
@@ -3,8 +3,8 @@ import difflib
 import sys
 from pathlib import Path
 
-import utils
 import exceptions
+import utils
 from bs4 import BeautifulSoup
 
 
@@ -21,14 +21,19 @@ def validate_commit(commit_to_diff, docx_current_version):
         raise exceptions.InvalidArgumentError("No commit file path provided.")
 
     if not Path(commit_to_diff).is_file():
-            raise FileNotFoundError("Commit file not found. Please provide a valid commit file path.")
-    
+        raise FileNotFoundError(
+            "Commit file not found. Please provide a valid commit file path."
+        )
+
     if Path(commit_to_diff).suffix.lower() != ".html":
-        raise exceptions.InvalidArgumentError("Commit file is not a .html file. Please provide a valid .html commit file")
+        raise exceptions.InvalidArgumentError(
+            "Commit file is not a .html file. Please provide a valid .html commit file"
+        )
 
     if not Path(docx_current_version).is_file():
-        raise FileNotFoundError("Docx file not found. Please provide a valid docx file path.")
-
+        raise FileNotFoundError(
+            "Docx file not found. Please provide a valid docx file path."
+        )
 
 
 def get_commit_html(commit_path):

--- a/commands/diff.py
+++ b/commands/diff.py
@@ -223,30 +223,42 @@ def write_redline_html_file(redline, filename="redline.html"):
     with open(filename, "w", encoding="utf-8", newline="\n") as f:
         f.write(utils.wrap_html(str(strip_number_attribute(redline))))
 
+def main():
+    if __name__ == "__main__":
 
-if __name__ == "__main__":
+        utils.check_sccs_layout()
 
-    utils.check_sccs_layout()
+        validate_commit(get_entered_commit_to_diff(), utils.current_file_docx_path)
 
-    validate_commit(get_entered_commit_to_diff(), utils.current_file_docx_path)
+        docx_current_version_html = utils.convert_docx_to_html()
 
-    docx_current_version_html = utils.convert_docx_to_html()
+        commit_html = get_commit_html(get_entered_commit_to_diff())
 
-    commit_html = get_commit_html(get_entered_commit_to_diff())
+        bs4_docx_current_version_soup = convert_html_to_soup(docx_current_version_html)
 
-    bs4_docx_current_version_soup = convert_html_to_soup(docx_current_version_html)
+        docx_current_version_list = format_bs4_html_list(bs4_docx_current_version_soup)
 
-    docx_current_version_list = format_bs4_html_list(bs4_docx_current_version_soup)
+        bs4_commit_soup = convert_html_to_soup(commit_html)
+        commit_list = format_bs4_html_list(bs4_commit_soup)
 
-    bs4_commit_soup = convert_html_to_soup(commit_html)
-    commit_list = format_bs4_html_list(bs4_commit_soup)
+        opcodes = get_opcodes(bs4_commit_soup, bs4_docx_current_version_soup)
 
-    opcodes = get_opcodes(bs4_commit_soup, bs4_docx_current_version_soup)
+        base_redline_html = get_redline_html(bs4_commit_soup)
 
-    base_redline_html = get_redline_html(bs4_commit_soup)
+        redline = format_redline_html(
+            base_redline_html, opcodes, commit_list, docx_current_version_list
+        )
 
-    redline = format_redline_html(
-        base_redline_html, opcodes, commit_list, docx_current_version_list
-    )
+        write_redline_html_file(redline)
 
-    write_redline_html_file(redline)
+    else:
+        raise exceptions.FileImportedAsModuleError(
+            "This file cannot be run as a module. Please run it as a script."
+        )
+    
+try:
+    main()
+except Exception as e: 
+    print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
+    raise exceptions.SCCSException
+

--- a/commands/exceptions.py
+++ b/commands/exceptions.py
@@ -188,3 +188,11 @@ class EmptyCommitMessageError(SCCSException):
     """Raised when an empty commit message is provided."""
 
     pass
+
+# Module Exceptions
+
+class FileImportedAsModuleError(SCCSException):
+    """Raised when a module cannot be found or imported."""
+
+    pass
+

--- a/commands/exceptions.py
+++ b/commands/exceptions.py
@@ -88,10 +88,6 @@ class AlreadyInitializedError(SCCSException):
     """Raised when the document has already been initialized with SCCS."""
     pass
 
-class InvalidInputError(SCCSException):
-    """Raised when an invalid input is provided."""
-    pass
-
 class InvalidFileTypeError(SCCSException):
     """Raised when a file of an invalid type is provided."""
     pass
@@ -132,8 +128,15 @@ class UncommittedChangesError(SCCSException):
     """Raised when there are uncommitted changes that prevent an action."""
     pass
 
+# Input Exceptions
 
+class InvalidInputError(SCCSException):
+    """Raised when an invalid input is provided."""
+    pass
 
+class EmptyCommitMessageError(SCCSException):
+    """Raised when an empty commit message is provided."""
+    pass
 
 
 

--- a/commands/exceptions.py
+++ b/commands/exceptions.py
@@ -2,36 +2,18 @@ class SCCSException(Exception):
     """Base class for SCCS exceptions."""
     pass
 
-class InvalidLayoutError(SCCSException):
-    """Raised when the SCCS directory layout is invalid or missing."""
-    pass
-
-class InvalidArgumentError(SCCSException):
-    """Raised when an invalid argument is provided to a command."""
-    pass
-
-class InvalidSubcommandError(SCCSException):
-    """Raised when an invalid subcommand is provided to a command."""
-    pass
-
-class BranchNotFoundError(SCCSException):
-    """Raised when a branch is not found."""
-    pass
-
-class CommitNotFoundError(SCCSException):
-    """Raised when a commit is not found."""
-    pass
-
-class DocumentNotFoundError(SCCSException):
-    """Raised when a document is not found."""
-    pass
+# Branch Exceptions
 
 class InvalidBranchNameError(SCCSException):
     """Raised when a branch name is invalid."""
     pass
 
-class UncommittedChangesError(SCCSException):
-    """Raised when there are uncommitted changes that prevent an action."""
+class BranchMissingFromMetadata(SCCSException):
+    """Raised when a branch is missing from the metadata."""
+    pass
+
+class BranchNotFoundError(SCCSException):
+    """Raised when a branch is not found."""
     pass
 
 class ConfigurationError(SCCSException):
@@ -46,36 +28,18 @@ class BranchDeletionError(SCCSException):
     """Raised when there is an error deleting a branch."""
     pass
 
-class CommitError(SCCSException):
-    """Raised when there is an error during the commit process."""
+class BranchAlreadyExistsError(SCCSException):
+    """Raised when a branch already exists."""
     pass
 
-class FileOperationError(SCCSException):
-    """Raised when a file or directory operation fails."""
+class BranchDoesNotExistError(SCCSException):
+    """Raised when a branch does not exist."""
     pass
 
-class UpdatingMetadataError(SCCSException):
-    """Raised when there is an error updating metadata files."""
-    pass
-
-class TemporaryFileError(SCCSException):
-    """Raised when there is an error creating or replacing a temporary file."""
-    pass
-
-class InvalidFileTypeError(SCCSException):
-    """Raised when a file of an invalid type is provided."""
-    pass
+# File Operation Exceptions
 
 class FileReadError(SCCSException):
     """Raised when there is an error reading a file."""
-    pass
-
-class InvalidInputError(SCCSException):
-    """Raised when an invalid input is provided."""
-    pass
-
-class AlreadyInitializedError(SCCSException):
-    """Raised when the document has already been initialized with SCCS."""
     pass
 
 class FileCopyError(SCCSException):
@@ -90,37 +54,63 @@ class FileOpenError(SCCSException):
     """Raised when there is an error opening a file."""
     pass
 
+class UpdatingMetadataError(SCCSException):
+    """Raised when there is an error updating metadata files."""
+    pass
+
+class TemporaryFileError(SCCSException):
+    """Raised when there is an error creating or replacing a temporary file."""
+    pass
+
+# Invalid Command Call Exceptions
+
+class InvalidArgumentError(SCCSException):
+    """Raised when an invalid argument is provided to a command."""
+    pass
+
+class InvalidSubcommandError(SCCSException):
+    """Raised when an invalid subcommand is provided to a command."""
+    pass
+
 class UnknownCommandError(SCCSException):
     """Raised when an unknown command is provided."""
     pass
 
-class BranchAlreadyExistsError(SCCSException):
-    """Raised when a branch already exists."""
+class InvalidLayoutError(SCCSException):
+    """Raised when the SCCS directory layout is invalid or missing."""
     pass
 
-class BranchDoesNotExistError(SCCSException):
-    """Raised when a branch does not exist."""
+class SCCSNotInitializedError(SCCSException):
+    """Raised when SCCS has not been initialized in the current directory."""
     pass
 
-class BranchMissingFromMetadata(SCCSException):
-    """Raised when a branch is missing from the metadata."""
+class AlreadyInitializedError(SCCSException):
+    """Raised when the document has already been initialized with SCCS."""
     pass
 
-class InvalidMetadataError(SCCSException):
-    """Raised when metadata files are corrupted or missing required keys."""
+class InvalidInputError(SCCSException):
+    """Raised when an invalid input is provided."""
     pass
 
-class UncommittedChangesError(SCCSException):
-    """Raised when there are uncommitted changes on the current branch."""
+class InvalidFileTypeError(SCCSException):
+    """Raised when a file of an invalid type is provided."""
+    pass
+
+# Not Found Exceptions
+
+class CommitNotFoundError(SCCSException):
+    """Raised when a commit is not found."""
+    pass
+
+class DocumentNotFoundError(SCCSException):
+    """Raised when a document is not found."""
     pass
 
 class CommitNotFoundError(SCCSException):
     """Raised when a commit object is not found."""
     pass
 
-class SCCSNotInitializedError(SCCSException):
-    """Raised when SCCS has not been initialized in the current directory."""
-    pass
+# Conversion Exceptions
 
 class DocumentHashingError(SCCSException):
     """Raised when there is an error hashing a document."""
@@ -129,3 +119,21 @@ class DocumentHashingError(SCCSException):
 class ConvertingDocumentToHTMLError(SCCSException):
     """Raised when there is an error converting a document to HTML."""
     pass
+
+# Metadata Exceptions
+
+class InvalidMetadataError(SCCSException):
+    """Raised when metadata files are corrupted or missing required keys."""
+    pass
+
+# Uncommitted changes Exceptions
+
+class UncommittedChangesError(SCCSException):
+    """Raised when there are uncommitted changes that prevent an action."""
+    pass
+
+
+
+
+
+

--- a/commands/exceptions.py
+++ b/commands/exceptions.py
@@ -38,10 +38,6 @@ class BranchDoesNotExistError(SCCSException):
 
 # File Operation Exceptions
 
-class FileReadError(SCCSException):
-    """Raised when there is an error reading a file."""
-    pass
-
 class FileCopyError(SCCSException):
     """Raised when there is an error copying a file."""
     pass

--- a/commands/exceptions.py
+++ b/commands/exceptions.py
@@ -194,7 +194,7 @@ class EmptyCommitMessageError(SCCSException):
 
 
 class FileImportedAsModuleError(SCCSException):
-    """Raised when a script is imported as a module but is intended to be run only as a 
+    """Raised when a script is imported as a module but is intended to be run only as a
     standalone script."""
 
     pass

--- a/commands/exceptions.py
+++ b/commands/exceptions.py
@@ -194,6 +194,6 @@ class EmptyCommitMessageError(SCCSException):
 
 
 class FileImportedAsModuleError(SCCSException):
-    """Raised when a module cannot be found or imported."""
+    """Raised when a script is imported as a module but is intended to be run only as a standalone script."""
 
     pass

--- a/commands/exceptions.py
+++ b/commands/exceptions.py
@@ -8,7 +8,7 @@ class InvalidBranchNameError(SCCSException):
     """Raised when a branch name is invalid."""
     pass
 
-class BranchMissingFromMetadata(SCCSException):
+class BranchMissingFromMetadataError(SCCSException):
     """Raised when a branch is missing from the metadata."""
     pass
 

--- a/commands/exceptions.py
+++ b/commands/exceptions.py
@@ -134,5 +134,15 @@ class EmptyCommitMessageError(SCCSException):
     """Raised when an empty commit message is provided."""
     pass
 
+# Exit Code Zero (0) Exceptions
+
+class UpdateCancelledExitZero(SCCSException):
+    """Raised when an update is cancelled by the user, resulting in a clean exit."""
+    pass
+
+class NoChangesToCommitExitZero(SCCSException):
+    """Raised when there are no changes to commit, resulting in a clean exit."""
+    pass
+
 
 

--- a/commands/exceptions.py
+++ b/commands/exceptions.py
@@ -125,16 +125,3 @@ class InvalidInputError(SCCSException):
 class EmptyCommitMessageError(SCCSException):
     """Raised when an empty commit message is provided."""
     pass
-
-# Exit Code Zero (0) Exceptions
-
-class UpdateCancelledExitZero(SCCSException):
-    """Raised when an update is cancelled by the user, resulting in a clean exit."""
-    pass
-
-class NoChangesToCommitExitZero(SCCSException):
-    """Raised when there are no changes to commit, resulting in a clean exit."""
-    pass
-
-
-

--- a/commands/exceptions.py
+++ b/commands/exceptions.py
@@ -32,10 +32,6 @@ class BranchAlreadyExistsError(SCCSException):
     """Raised when a branch already exists."""
     pass
 
-class BranchDoesNotExistError(SCCSException):
-    """Raised when a branch does not exist."""
-    pass
-
 # File Operation Exceptions
 
 class FileCopyError(SCCSException):

--- a/commands/exceptions.py
+++ b/commands/exceptions.py
@@ -86,10 +86,6 @@ class InvalidFileTypeError(SCCSException):
 
 # Not Found Exceptions
 
-class CommitNotFoundError(SCCSException):
-    """Raised when a commit is not found."""
-    pass
-
 class DocumentNotFoundError(SCCSException):
     """Raised when a document is not found."""
     pass

--- a/commands/exceptions.py
+++ b/commands/exceptions.py
@@ -1,0 +1,131 @@
+class SCCSException(Exception):
+    """Base class for SCCS exceptions."""
+    pass
+
+class InvalidLayoutError(SCCSException):
+    """Raised when the SCCS directory layout is invalid or missing."""
+    pass
+
+class InvalidArgumentError(SCCSException):
+    """Raised when an invalid argument is provided to a command."""
+    pass
+
+class InvalidSubcommandError(SCCSException):
+    """Raised when an invalid subcommand is provided to a command."""
+    pass
+
+class BranchNotFoundError(SCCSException):
+    """Raised when a branch is not found."""
+    pass
+
+class CommitNotFoundError(SCCSException):
+    """Raised when a commit is not found."""
+    pass
+
+class DocumentNotFoundError(SCCSException):
+    """Raised when a document is not found."""
+    pass
+
+class InvalidBranchNameError(SCCSException):
+    """Raised when a branch name is invalid."""
+    pass
+
+class UncommittedChangesError(SCCSException):
+    """Raised when there are uncommitted changes that prevent an action."""
+    pass
+
+class ConfigurationError(SCCSException):
+    """Raised when there is an error in the SCCS configuration."""
+    pass
+
+class BranchCreationError(SCCSException):
+    """Raised when there is an error creating a new branch."""
+    pass
+
+class BranchDeletionError(SCCSException):
+    """Raised when there is an error deleting a branch."""
+    pass
+
+class CommitError(SCCSException):
+    """Raised when there is an error during the commit process."""
+    pass
+
+class FileOperationError(SCCSException):
+    """Raised when a file or directory operation fails."""
+    pass
+
+class UpdatingMetadataError(SCCSException):
+    """Raised when there is an error updating metadata files."""
+    pass
+
+class TemporaryFileError(SCCSException):
+    """Raised when there is an error creating or replacing a temporary file."""
+    pass
+
+class InvalidFileTypeError(SCCSException):
+    """Raised when a file of an invalid type is provided."""
+    pass
+
+class FileReadError(SCCSException):
+    """Raised when there is an error reading a file."""
+    pass
+
+class InvalidInputError(SCCSException):
+    """Raised when an invalid input is provided."""
+    pass
+
+class AlreadyInitializedError(SCCSException):
+    """Raised when the document has already been initialized with SCCS."""
+    pass
+
+class FileCopyError(SCCSException):
+    """Raised when there is an error copying a file."""
+    pass
+
+class FileWriteError(SCCSException):
+    """Raised when there is an error writing to a file."""
+    pass
+
+class FileOpenError(SCCSException):
+    """Raised when there is an error opening a file."""
+    pass
+
+class UnknownCommandError(SCCSException):
+    """Raised when an unknown command is provided."""
+    pass
+
+class BranchAlreadyExistsError(SCCSException):
+    """Raised when a branch already exists."""
+    pass
+
+class BranchDoesNotExistError(SCCSException):
+    """Raised when a branch does not exist."""
+    pass
+
+class BranchMissingFromMetadata(SCCSException):
+    """Raised when a branch is missing from the metadata."""
+    pass
+
+class InvalidMetadataError(SCCSException):
+    """Raised when metadata files are corrupted or missing required keys."""
+    pass
+
+class UncommittedChangesError(SCCSException):
+    """Raised when there are uncommitted changes on the current branch."""
+    pass
+
+class CommitNotFoundError(SCCSException):
+    """Raised when a commit object is not found."""
+    pass
+
+class SCCSNotInitializedError(SCCSException):
+    """Raised when SCCS has not been initialized in the current directory."""
+    pass
+
+class DocumentHashingError(SCCSException):
+    """Raised when there is an error hashing a document."""
+    pass
+
+class ConvertingDocumentToHTMLError(SCCSException):
+    """Raised when there is an error converting a document to HTML."""
+    pass

--- a/commands/exceptions.py
+++ b/commands/exceptions.py
@@ -189,10 +189,11 @@ class EmptyCommitMessageError(SCCSException):
 
     pass
 
+
 # Module Exceptions
+
 
 class FileImportedAsModuleError(SCCSException):
     """Raised when a module cannot be found or imported."""
 
     pass
-

--- a/commands/exceptions.py
+++ b/commands/exceptions.py
@@ -194,6 +194,7 @@ class EmptyCommitMessageError(SCCSException):
 
 
 class FileImportedAsModuleError(SCCSException):
-    """Raised when a script is imported as a module but is intended to be run only as a standalone script."""
+    """Raised when a script is imported as a module but is intended to be run only as a 
+    standalone script."""
 
     pass

--- a/commands/exceptions.py
+++ b/commands/exceptions.py
@@ -1,127 +1,190 @@
 class SCCSException(Exception):
     """Base class for SCCS exceptions."""
+
     pass
+
 
 # Branch Exceptions
 
+
 class InvalidBranchNameError(SCCSException):
     """Raised when a branch name is invalid."""
+
     pass
+
 
 class BranchMissingFromMetadataError(SCCSException):
     """Raised when a branch is missing from the metadata."""
+
     pass
+
 
 class BranchNotFoundError(SCCSException):
     """Raised when a branch is not found."""
+
     pass
+
 
 class ConfigurationError(SCCSException):
     """Raised when there is an error in the SCCS configuration."""
+
     pass
+
 
 class BranchCreationError(SCCSException):
     """Raised when there is an error creating a new branch."""
+
     pass
+
 
 class BranchDeletionError(SCCSException):
     """Raised when there is an error deleting a branch."""
+
     pass
+
 
 class BranchAlreadyExistsError(SCCSException):
     """Raised when a branch already exists."""
+
     pass
+
 
 # File Operation Exceptions
 
+
 class FileCopyError(SCCSException):
     """Raised when there is an error copying a file."""
+
     pass
+
 
 class FileWriteError(SCCSException):
     """Raised when there is an error writing to a file."""
+
     pass
+
 
 class FileOpenError(SCCSException):
     """Raised when there is an error opening a file."""
+
     pass
+
 
 class UpdatingMetadataError(SCCSException):
     """Raised when there is an error updating metadata files."""
+
     pass
+
 
 class TemporaryFileError(SCCSException):
     """Raised when there is an error creating or replacing a temporary file."""
+
     pass
+
 
 # Invalid Command Call Exceptions
 
+
 class InvalidArgumentError(SCCSException):
     """Raised when an invalid argument is provided to a command."""
+
     pass
+
 
 class InvalidSubcommandError(SCCSException):
     """Raised when an invalid subcommand is provided to a command."""
+
     pass
+
 
 class UnknownCommandError(SCCSException):
     """Raised when an unknown command is provided."""
+
     pass
+
 
 class InvalidLayoutError(SCCSException):
     """Raised when the SCCS directory layout is invalid or missing."""
+
     pass
+
 
 class SCCSNotInitializedError(SCCSException):
     """Raised when SCCS has not been initialized in the current directory."""
+
     pass
+
 
 class AlreadyInitializedError(SCCSException):
     """Raised when the document has already been initialized with SCCS."""
+
     pass
+
 
 class InvalidFileTypeError(SCCSException):
     """Raised when a file of an invalid type is provided."""
+
     pass
+
 
 # Not Found Exceptions
 
+
 class DocumentNotFoundError(SCCSException):
     """Raised when a document is not found."""
+
     pass
+
 
 class CommitNotFoundError(SCCSException):
     """Raised when a commit object is not found."""
+
     pass
+
 
 # Conversion Exceptions
 
+
 class DocumentHashingError(SCCSException):
     """Raised when there is an error hashing a document."""
+
     pass
+
 
 class ConvertingDocumentToHTMLError(SCCSException):
     """Raised when there is an error converting a document to HTML."""
+
     pass
+
 
 # Metadata Exceptions
 
+
 class InvalidMetadataError(SCCSException):
     """Raised when metadata files are corrupted or missing required keys."""
+
     pass
+
 
 # Uncommitted changes Exceptions
 
+
 class UncommittedChangesError(SCCSException):
     """Raised when there are uncommitted changes that prevent an action."""
+
     pass
+
 
 # Input Exceptions
 
+
 class InvalidInputError(SCCSException):
     """Raised when an invalid input is provided."""
+
     pass
+
 
 class EmptyCommitMessageError(SCCSException):
     """Raised when an empty commit message is provided."""
+
     pass

--- a/commands/help.py
+++ b/commands/help.py
@@ -1,4 +1,3 @@
-
 MESSAGES_TO_PRINT = [
     "SCCS Help",
     "Available commands:",

--- a/commands/help.py
+++ b/commands/help.py
@@ -1,3 +1,5 @@
+import exceptions
+
 MESSAGES_TO_PRINT = [
     "SCCS Help",
     "Available commands:",

--- a/commands/help.py
+++ b/commands/help.py
@@ -1,4 +1,3 @@
-import exceptions
 
 MESSAGES_TO_PRINT = [
     "SCCS Help",

--- a/commands/help.py
+++ b/commands/help.py
@@ -1,5 +1,6 @@
-import exceptions
 import sys
+
+import exceptions
 
 MESSAGES_TO_PRINT = [
     "SCCS Help",

--- a/commands/help.py
+++ b/commands/help.py
@@ -1,4 +1,5 @@
 import exceptions
+import sys
 
 MESSAGES_TO_PRINT = [
     "SCCS Help",
@@ -24,16 +25,21 @@ def print_help(messages):
 
 
 def main():
-    if __name__ == "__main__":
-        print_help(MESSAGES_TO_PRINT)
-    else:
-        raise exceptions.FileImportedAsModuleError(
-            "This file cannot be run as a module. Please run it as a script."
-        )
+    print_help(MESSAGES_TO_PRINT)
 
 
-try:
-    main()
-except Exception as e:
-    print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
-    raise exceptions.SCCSException
+if __name__ == "__main__":
+    try:
+        main()
+
+    except exceptions.SCCSException as e:
+        print(f"An error occurred:\n{e}\n")
+        sys.exit(1)
+
+    except Exception as e:
+        print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
+        sys.exit(2)
+else:
+    raise exceptions.FileImportedAsModuleError(
+        "This file cannot be run as a module. Please run it as a script."
+    )

--- a/commands/help.py
+++ b/commands/help.py
@@ -1,3 +1,6 @@
+import exceptions
+
+
 MESSAGES_TO_PRINT = [
     "SCCS Help",
     "Available commands:",
@@ -21,5 +24,17 @@ def print_help(messages):
         print(item)
 
 
-if __name__ == "__main__":
-    print_help(MESSAGES_TO_PRINT)
+def main():
+    if __name__ == "__main__":
+        print_help(MESSAGES_TO_PRINT)
+    else:
+        raise exceptions.FileImportedAsModuleError(
+            "This file cannot be run as a module. Please run it as a script."
+        )
+
+
+try:
+    main()
+except Exception as e:
+    print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
+    raise exceptions.SCCSException

--- a/commands/help.py
+++ b/commands/help.py
@@ -1,6 +1,5 @@
 import exceptions
 
-
 MESSAGES_TO_PRINT = [
     "SCCS Help",
     "Available commands:",

--- a/commands/init.py
+++ b/commands/init.py
@@ -282,56 +282,63 @@ def confirmation_message():
 
 
 def main():
-    if __name__ == "__main__":
-        check_if_arg_entered(get_entered_document_path())
+    check_if_arg_entered(get_entered_document_path())
 
-        check_for_prev_init()
+    check_for_prev_init()
 
-        check_file_requirements()
+    check_file_requirements()
 
-        config_user_name = ask_config_input("name")
+    config_user_name = ask_config_input("name")
 
-        config_user_email = ask_config_input("email")
+    config_user_email = ask_config_input("email")
 
-        current_iso_time = get_current_iso_time()
+    current_iso_time = get_current_iso_time()
 
-        sha_hash = create_commit_sha_hash(
-            current_iso_time, config_user_name, config_user_email
+    sha_hash = create_commit_sha_hash(
+        current_iso_time, config_user_name, config_user_email
+    )
+
+    create_sccs_directory_layout()
+
+    document_as_html = utils.convert_docx_to_html(get_entered_document_path())
+
+    move_document_to_repo_directory()
+
+    copy_document_to_objects_as_docx_and_html(sha_hash, document_as_html)
+
+    write_history_data(sha_hash, config_user_name, config_user_email)
+
+    write_commit_message_data(sha_hash)
+
+    write_config_data(config_user_name, config_user_email)
+
+    current_branch_binary_hash = utils.hash_current_docx_binary(
+        docx_path=os.path.join(
+            get_document_repo_path(), Path(get_entered_document_path()).name
         )
+    )
 
-        create_sccs_directory_layout()
+    write_hashed_file_commit_data(sha_hash, current_branch_binary_hash)
 
-        document_as_html = utils.convert_docx_to_html(get_entered_document_path())
+    write_branch_data()
 
-        move_document_to_repo_directory()
-
-        copy_document_to_objects_as_docx_and_html(sha_hash, document_as_html)
-
-        write_history_data(sha_hash, config_user_name, config_user_email)
-
-        write_commit_message_data(sha_hash)
-
-        write_config_data(config_user_name, config_user_email)
-
-        current_branch_binary_hash = utils.hash_current_docx_binary(
-            docx_path=os.path.join(
-                get_document_repo_path(), Path(get_entered_document_path()).name
-            )
-        )
-
-        write_hashed_file_commit_data(sha_hash, current_branch_binary_hash)
-
-        write_branch_data()
-
-        confirmation_message()
-    else:
-        raise exceptions.FileImportedAsModuleError(
-            "This file cannot be run as a module. Please run it as a script."
-        )
+    confirmation_message()
 
 
-try:
-    main()
-except Exception as e:
-    print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
-    raise exceptions.SCCSException
+
+
+if __name__ == "__main__":
+    try:
+        main()
+
+    except exceptions.SCCSException as e:
+        print(f"An error occurred:\n{e}\n")
+        sys.exit(1)
+
+    except Exception as e:
+        print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
+        sys.exit(2)
+else:
+    raise exceptions.FileImportedAsModuleError(
+        "This file cannot be run as a module. Please run it as a script."
+    )

--- a/commands/init.py
+++ b/commands/init.py
@@ -325,8 +325,6 @@ def main():
     confirmation_message()
 
 
-
-
 if __name__ == "__main__":
     try:
         main()

--- a/commands/init.py
+++ b/commands/init.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from pathlib import Path
 
 import utils
+import exceptions
 
 
 def get_entered_document_path():

--- a/commands/init.py
+++ b/commands/init.py
@@ -63,7 +63,7 @@ def check_file_requirements():
             "File is not a .docx file. Please provide a valid .docx file."
         )
     if not Path(entered_path).is_file():
-        raise exceptions.InvalidFilePathError("File does not exist.")
+        raise FileNotFoundError("File does not exist.")
 
 
 def create_commit_sha_hash(timestamp, user_name, user_email):

--- a/commands/init.py
+++ b/commands/init.py
@@ -122,7 +122,7 @@ def copy_document_to_objects_as_docx_and_html(sha_hash, html, styles=None):
             os.path.join(repo_path, ".sccs", "objects", "docx", f"{sha_hash}.docx"),
         )
     except Exception as e:
-        raise exceptions.FileCopyError(f"Error copying document to objects: {e}")
+        raise exceptions.FileCopyError from e
 
     try:
         with open(
@@ -133,7 +133,7 @@ def copy_document_to_objects_as_docx_and_html(sha_hash, html, styles=None):
         ) as f:
             f.write(styles + html)
     except Exception as e:
-        raise exceptions.FileWriteError(f"Error writing HTML file: {e}")
+        raise exceptions.FileWriteError from e
 
     try:
         with open(
@@ -146,7 +146,7 @@ def copy_document_to_objects_as_docx_and_html(sha_hash, html, styles=None):
         ) as f:
             f.write(utils.wrap_html(html))
     except Exception as e:
-        raise exceptions.FileWriteError(f"Error writing view HTML file: {e}")
+        raise exceptions.FileWriteError from e
 
 
 def get_current_iso_time():
@@ -190,7 +190,7 @@ def write_history_data(sha_hash, config_user_name, config_user_email):
         ) as f:
             json.dump(history_data, f, indent=4)
     except Exception as e:
-        raise exceptions.FileOpenError(f"Error opening history data file: {e}")
+        raise exceptions.FileOpenError from e
 
 
 def write_commit_message_data(sha_hash):
@@ -212,7 +212,7 @@ def write_commit_message_data(sha_hash):
         ) as f:
             json.dump(commit_message_data, f, indent=4)
     except Exception as e:
-        raise exceptions.FileOpenError(f"Error opening commit message data file: {e}")
+        raise exceptions.FileOpenError from e
 
 
 def write_config_data(config_user_name, config_user_email):
@@ -228,7 +228,7 @@ def write_config_data(config_user_name, config_user_email):
         ) as f:
             json.dump(config_data, f, indent=4)
     except Exception as e:
-        raise exceptions.UpdatingMetadataError(f"Error updating config data file: {e}")
+        raise exceptions.UpdatingMetadataError from e
 
 
 def write_hashed_file_commit_data(sha_hash, hashed_file):
@@ -251,9 +251,7 @@ def write_hashed_file_commit_data(sha_hash, hashed_file):
         ) as f:
             json.dump(commit_file_hash_data, f, indent=4)
     except Exception as e:
-        raise exceptions.UpdatingMetadataError(
-            f"Error updating commit file hash data file: {e}"
-        )
+        raise exceptions.UpdatingMetadataError from e
 
 
 def write_branch_data():
@@ -274,9 +272,7 @@ def write_branch_data():
         ) as f:
             json.dump(branches_data, f, indent=4)
     except Exception as e:
-        raise exceptions.UpdatingMetadataError(
-            f"Error updating branches data file: {e}"
-        )
+        raise exceptions.UpdatingMetadataError from e
 
 
 def confirmation_message():

--- a/commands/init.py
+++ b/commands/init.py
@@ -169,7 +169,8 @@ def write_history_data(sha_hash, config_user_name, config_user_email):
             f"{sha_hash}": {
                 "timestamp": get_current_iso_time(),
                 "author": f"{config_user_name} <{config_user_email}>",
-                "message": "initial commit (This is a default commit message for initial version)",
+                "message": "initial commit (This is a default commit message for "
+                "initial version)",
             }
         },
     }
@@ -194,7 +195,8 @@ def write_history_data(sha_hash, config_user_name, config_user_email):
 
 def write_commit_message_data(sha_hash):
     commit_message_data = {
-        f"{sha_hash}": "initial commit (This is a default commit message for initial version)"
+        f"{sha_hash}": "initial commit (This is a default commit message for initial "
+        "version)"
     }
     try:
         with open(

--- a/commands/init.py
+++ b/commands/init.py
@@ -29,8 +29,7 @@ def check_if_arg_entered(arg):
     """Check that a file path argument was provided."""
 
     if not arg:
-        print("No file path provided")
-        sys.exit(1)
+        raise exceptions.InvalidArgumentError("No file path provided.")
 
 
 def ask_config_input(data):
@@ -38,8 +37,7 @@ def ask_config_input(data):
 
     data_value = input(f"Enter your {data}: ").strip()
     if data_value == "":
-        print(f"{data.capitalize()} Cannot be empty.")
-        sys.exit(1)
+        raise exceptions.InvalidInputError(f"{data} cannot be empty.")
     else:
         return data_value
 
@@ -48,22 +46,20 @@ def check_for_prev_init():
     """Exit if the document has already been initialized with SCCS."""
 
     if Path(os.path.join(get_document_repo_path(), ".sccs")).is_dir():
-        print("This file has already been initialized with SCCS")
-        sys.exit(1)
+        raise exceptions.AlreadyInitializedError("This file has already been initialized with SCCS.")
 
 
 def check_file_requirements():
     """Validate that the entered path points to an existing .docx file."""
 
     entered_path = get_entered_document_path()
-    if (
-        not entered_path
-        or Path(entered_path).suffix.lower() != ".docx"
-        or not Path(entered_path).is_file()
-    ):
-        print("Invalid file path, make sure the file exists and is a .docx file")
-        sys.exit(1)
+    if not entered_path:
+        raise exceptions.InvalidArgumentError("No file path provided.")
 
+    if Path(entered_path).suffix.lower() != ".docx":
+        raise exceptions.InvalidFileTypeError("File is not a .docx file. Please provide a valid .docx file.")
+    if not Path(entered_path).is_file():
+        raise exceptions.InvalidFilePathError("File does not exist.")
 
 def create_commit_sha_hash(timestamp, user_name, user_email):
     """Create a SHA-256 hash for the initial commit."""
@@ -78,8 +74,8 @@ def create_sccs_directory_layout():
 
     repo_path = get_document_repo_path()
     if not repo_path:
-        print("Invalid file path")
-        sys.exit(1)
+        raise exceptions.InvalidArgumentError("No file path provided.")
+    
 
     os.makedirs(repo_path, exist_ok=True)
     os.makedirs(os.path.join(repo_path, ".sccs"), exist_ok=True)
@@ -122,8 +118,9 @@ def copy_document_to_objects_as_docx_and_html(sha_hash, html, styles=None):
             os.path.join(repo_path, ".sccs", "objects", "docx", f"{sha_hash}.docx"),
         )
     except Exception as e:
-        print(f"Error copying document to objects: {e}")
-        sys.exit(1)
+        raise exceptions.FileCopyError(f"Error copying document to objects: {e}")
+
+
 
     try:
         with open(
@@ -134,8 +131,8 @@ def copy_document_to_objects_as_docx_and_html(sha_hash, html, styles=None):
         ) as f:
             f.write(styles + html)
     except Exception as e:
-        print(f"Error writing HTML file: {e}")
-        sys.exit(1)
+        raise exceptions.FileOpenError(f"Error writing HTML file: {e}")
+
 
     try:
         with open(
@@ -148,8 +145,9 @@ def copy_document_to_objects_as_docx_and_html(sha_hash, html, styles=None):
         ) as f:
             f.write(utils.wrap_html(html))
     except Exception as e:
-        print(f"Error writing view HTML file: {e}")
-        sys.exit(1)
+        raise exceptions.FileOpenError(f"Error writing view HTML file: {e}")
+
+
 
 
 def get_current_iso_time():
@@ -192,8 +190,9 @@ def write_history_data(sha_hash, config_user_name, config_user_email):
         ) as f:
             json.dump(history_data, f, indent=4)
     except Exception as e:
-        print(f"Error updating commit history file: {e}")
-        sys.exit(1)
+        raise exceptions.FileOpenError(f"Error opening history data file: {e}")
+
+
 
 
 def write_commit_message_data(sha_hash):
@@ -214,9 +213,7 @@ def write_commit_message_data(sha_hash):
         ) as f:
             json.dump(commit_message_data, f, indent=4)
     except Exception as e:
-        print(f"Error opening commit message data file: {e}")
-        sys.exit(1)
-
+        raise exceptions.FileOpenError(f"Error opening commit message data file: {e}")
 
 def write_config_data(config_user_name, config_user_email):
     """Write the user config JSON file."""
@@ -231,9 +228,7 @@ def write_config_data(config_user_name, config_user_email):
         ) as f:
             json.dump(config_data, f, indent=4)
     except Exception as e:
-        print(f"Error updating config data file: {e}")
-        sys.exit(1)
-
+        raise exceptions.UpdatingMetadataError(f"Error updating config data file: {e}")
 
 def write_hashed_file_commit_data(sha_hash, hashed_file):
     """Write the initial commit file binary hash JSON file."""
@@ -255,8 +250,8 @@ def write_hashed_file_commit_data(sha_hash, hashed_file):
         ) as f:
             json.dump(commit_file_hash_data, f, indent=4)
     except Exception as e:
-        print(f"Error updating commit file hash data file: {e}")
-        sys.exit(1)
+        raise exceptions.UpdatingMetadataError(f"Error updating commit file hash data file: {e}")
+
 
 
 def write_branch_data():
@@ -277,8 +272,9 @@ def write_branch_data():
         ) as f:
             json.dump(branches_data, f, indent=4)
     except Exception as e:
-        print(f"Error opening branch data file: {e}")
-        sys.exit(1)
+        raise exceptions.UpdatingMetadataError(f"Error updating branches data file: {e}")
+
+
 
 
 def confirmation_message():

--- a/commands/init.py
+++ b/commands/init.py
@@ -6,8 +6,8 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
-import utils
 import exceptions
+import utils
 
 
 def get_entered_document_path():
@@ -46,7 +46,9 @@ def check_for_prev_init():
     """Exit if the document has already been initialized with SCCS."""
 
     if Path(os.path.join(get_document_repo_path(), ".sccs")).is_dir():
-        raise exceptions.AlreadyInitializedError("This file has already been initialized with SCCS.")
+        raise exceptions.AlreadyInitializedError(
+            "This file has already been initialized with SCCS."
+        )
 
 
 def check_file_requirements():
@@ -57,9 +59,12 @@ def check_file_requirements():
         raise exceptions.InvalidArgumentError("No file path provided.")
 
     if Path(entered_path).suffix.lower() != ".docx":
-        raise exceptions.InvalidFileTypeError("File is not a .docx file. Please provide a valid .docx file.")
+        raise exceptions.InvalidFileTypeError(
+            "File is not a .docx file. Please provide a valid .docx file."
+        )
     if not Path(entered_path).is_file():
         raise exceptions.InvalidFilePathError("File does not exist.")
+
 
 def create_commit_sha_hash(timestamp, user_name, user_email):
     """Create a SHA-256 hash for the initial commit."""
@@ -75,7 +80,6 @@ def create_sccs_directory_layout():
     repo_path = get_document_repo_path()
     if not repo_path:
         raise exceptions.InvalidArgumentError("No file path provided.")
-    
 
     os.makedirs(repo_path, exist_ok=True)
     os.makedirs(os.path.join(repo_path, ".sccs"), exist_ok=True)
@@ -120,8 +124,6 @@ def copy_document_to_objects_as_docx_and_html(sha_hash, html, styles=None):
     except Exception as e:
         raise exceptions.FileCopyError(f"Error copying document to objects: {e}")
 
-
-
     try:
         with open(
             os.path.join(repo_path, ".sccs", "objects", "html", f"{sha_hash}.html"),
@@ -132,7 +134,6 @@ def copy_document_to_objects_as_docx_and_html(sha_hash, html, styles=None):
             f.write(styles + html)
     except Exception as e:
         raise exceptions.FileWriteError(f"Error writing HTML file: {e}")
-
 
     try:
         with open(
@@ -146,8 +147,6 @@ def copy_document_to_objects_as_docx_and_html(sha_hash, html, styles=None):
             f.write(utils.wrap_html(html))
     except Exception as e:
         raise exceptions.FileWriteError(f"Error writing view HTML file: {e}")
-
-
 
 
 def get_current_iso_time():
@@ -193,8 +192,6 @@ def write_history_data(sha_hash, config_user_name, config_user_email):
         raise exceptions.FileOpenError(f"Error opening history data file: {e}")
 
 
-
-
 def write_commit_message_data(sha_hash):
     commit_message_data = {
         f"{sha_hash}": "initial commit (This is a default commit message for initial version)"
@@ -215,6 +212,7 @@ def write_commit_message_data(sha_hash):
     except Exception as e:
         raise exceptions.FileOpenError(f"Error opening commit message data file: {e}")
 
+
 def write_config_data(config_user_name, config_user_email):
     """Write the user config JSON file."""
 
@@ -229,6 +227,7 @@ def write_config_data(config_user_name, config_user_email):
             json.dump(config_data, f, indent=4)
     except Exception as e:
         raise exceptions.UpdatingMetadataError(f"Error updating config data file: {e}")
+
 
 def write_hashed_file_commit_data(sha_hash, hashed_file):
     """Write the initial commit file binary hash JSON file."""
@@ -250,8 +249,9 @@ def write_hashed_file_commit_data(sha_hash, hashed_file):
         ) as f:
             json.dump(commit_file_hash_data, f, indent=4)
     except Exception as e:
-        raise exceptions.UpdatingMetadataError(f"Error updating commit file hash data file: {e}")
-
+        raise exceptions.UpdatingMetadataError(
+            f"Error updating commit file hash data file: {e}"
+        )
 
 
 def write_branch_data():
@@ -272,9 +272,9 @@ def write_branch_data():
         ) as f:
             json.dump(branches_data, f, indent=4)
     except Exception as e:
-        raise exceptions.UpdatingMetadataError(f"Error updating branches data file: {e}")
-
-
+        raise exceptions.UpdatingMetadataError(
+            f"Error updating branches data file: {e}"
+        )
 
 
 def confirmation_message():

--- a/commands/init.py
+++ b/commands/init.py
@@ -324,13 +324,14 @@ def main():
         write_branch_data()
 
         confirmation_message()
-    else: 
+    else:
         raise exceptions.FileImportedAsModuleError(
             "This file cannot be run as a module. Please run it as a script."
         )
 
+
 try:
     main()
-except Exception as e: 
+except Exception as e:
     print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
     raise exceptions.SCCSException

--- a/commands/init.py
+++ b/commands/init.py
@@ -131,7 +131,7 @@ def copy_document_to_objects_as_docx_and_html(sha_hash, html, styles=None):
         ) as f:
             f.write(styles + html)
     except Exception as e:
-        raise exceptions.FileOpenError(f"Error writing HTML file: {e}")
+        raise exceptions.FileWriteError(f"Error writing HTML file: {e}")
 
 
     try:
@@ -145,7 +145,7 @@ def copy_document_to_objects_as_docx_and_html(sha_hash, html, styles=None):
         ) as f:
             f.write(utils.wrap_html(html))
     except Exception as e:
-        raise exceptions.FileOpenError(f"Error writing view HTML file: {e}")
+        raise exceptions.FileWriteError(f"Error writing view HTML file: {e}")
 
 
 

--- a/commands/init.py
+++ b/commands/init.py
@@ -281,45 +281,56 @@ def confirmation_message():
     print("SCCS initialization complete.")
 
 
-if __name__ == "__main__":
-    check_if_arg_entered(get_entered_document_path())
+def main():
+    if __name__ == "__main__":
+        check_if_arg_entered(get_entered_document_path())
 
-    check_for_prev_init()
+        check_for_prev_init()
 
-    check_file_requirements()
+        check_file_requirements()
 
-    config_user_name = ask_config_input("name")
+        config_user_name = ask_config_input("name")
 
-    config_user_email = ask_config_input("email")
+        config_user_email = ask_config_input("email")
 
-    current_iso_time = get_current_iso_time()
+        current_iso_time = get_current_iso_time()
 
-    sha_hash = create_commit_sha_hash(
-        current_iso_time, config_user_name, config_user_email
-    )
-
-    create_sccs_directory_layout()
-
-    document_as_html = utils.convert_docx_to_html(get_entered_document_path())
-
-    move_document_to_repo_directory()
-
-    copy_document_to_objects_as_docx_and_html(sha_hash, document_as_html)
-
-    write_history_data(sha_hash, config_user_name, config_user_email)
-
-    write_commit_message_data(sha_hash)
-
-    write_config_data(config_user_name, config_user_email)
-
-    current_branch_binary_hash = utils.hash_current_docx_binary(
-        docx_path=os.path.join(
-            get_document_repo_path(), Path(get_entered_document_path()).name
+        sha_hash = create_commit_sha_hash(
+            current_iso_time, config_user_name, config_user_email
         )
-    )
 
-    write_hashed_file_commit_data(sha_hash, current_branch_binary_hash)
+        create_sccs_directory_layout()
 
-    write_branch_data()
+        document_as_html = utils.convert_docx_to_html(get_entered_document_path())
 
-    confirmation_message()
+        move_document_to_repo_directory()
+
+        copy_document_to_objects_as_docx_and_html(sha_hash, document_as_html)
+
+        write_history_data(sha_hash, config_user_name, config_user_email)
+
+        write_commit_message_data(sha_hash)
+
+        write_config_data(config_user_name, config_user_email)
+
+        current_branch_binary_hash = utils.hash_current_docx_binary(
+            docx_path=os.path.join(
+                get_document_repo_path(), Path(get_entered_document_path()).name
+            )
+        )
+
+        write_hashed_file_commit_data(sha_hash, current_branch_binary_hash)
+
+        write_branch_data()
+
+        confirmation_message()
+    else: 
+        raise exceptions.FileImportedAsModuleError(
+            "This file cannot be run as a module. Please run it as a script."
+        )
+
+try:
+    main()
+except Exception as e: 
+    print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
+    raise exceptions.SCCSException

--- a/commands/log.py
+++ b/commands/log.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 
 import utils
+import exceptions
 
 
 def get_log_data(cwd=None, current_branch=None):

--- a/commands/log.py
+++ b/commands/log.py
@@ -4,8 +4,6 @@ import sys
 from pathlib import Path
 
 import utils
-import exceptions
-
 
 def get_log_data(cwd=None, current_branch=None):
     """Retrieve the commit log data from the history JSON file."""

--- a/commands/log.py
+++ b/commands/log.py
@@ -47,19 +47,23 @@ def print_log():
 
 
 def main():
-    if __name__ == "__main__":
+    utils.check_sccs_layout()
 
-        utils.check_sccs_layout()
-
-        print_log()
-    else:
-        raise exceptions.FileImportedAsModuleError(
-            "This file cannot be run as a module. Please run it as a script."
-        )
+    print_log()
 
 
-try:
-    main()
-except Exception as e:
-    print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
-    raise exceptions.SCCSException
+if __name__ == "__main__":
+    try:
+        main()
+
+    except exceptions.SCCSException as e:
+        print(f"An error occurred:\n{e}\n")
+        sys.exit(1)
+
+    except Exception as e:
+        print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
+        sys.exit(2)
+else:
+    raise exceptions.FileImportedAsModuleError(
+        "This file cannot be run as a module. Please run it as a script."
+    )

--- a/commands/log.py
+++ b/commands/log.py
@@ -21,7 +21,8 @@ def get_log_data(cwd=None, current_branch=None):
 
     if not Path(log_path).is_file():
         raise FileNotFoundError(
-            "History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "History file not found. Please run 'sccs init <file_path>' to initialize "
+            "SCCS for this file."
         )
 
     with open(log_path, "r", encoding="utf-8", newline="\n") as log_file:

--- a/commands/log.py
+++ b/commands/log.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import utils
 
+
 def get_log_data(cwd=None, current_branch=None):
     """Retrieve the commit log data from the history JSON file."""
 
@@ -19,8 +20,9 @@ def get_log_data(cwd=None, current_branch=None):
     )
 
     if not Path(log_path).is_file():
-        raise FileNotFoundError("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
-
+        raise FileNotFoundError(
+            "History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
 
     with open(log_path, "r", encoding="utf-8", newline="\n") as log_file:
         log_data = json.load(log_file)

--- a/commands/log.py
+++ b/commands/log.py
@@ -3,6 +3,7 @@ import os
 import sys
 from pathlib import Path
 
+import exceptions
 import utils
 
 
@@ -45,8 +46,20 @@ def print_log():
         )
 
 
-if __name__ == "__main__":
+def main():
+    if __name__ == "__main__":
 
-    utils.check_sccs_layout()
+        utils.check_sccs_layout()
 
-    print_log()
+        print_log()
+    else:
+        raise exceptions.FileImportedAsModuleError(
+            "This file cannot be run as a module. Please run it as a script."
+        )
+
+
+try:
+    main()
+except Exception as e:
+    print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
+    raise exceptions.SCCSException

--- a/commands/log.py
+++ b/commands/log.py
@@ -21,11 +21,8 @@ def get_log_data(cwd=None, current_branch=None):
     )
 
     if not Path(log_path).is_file():
-        print(
-            "Log file not found. Please make sure the file has been initialized with "
-            "'sccs init <file_path>'"
-        )
-        sys.exit(1)
+        raise FileNotFoundError("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+
 
     with open(log_path, "r", encoding="utf-8", newline="\n") as log_file:
         log_data = json.load(log_file)

--- a/commands/open.py
+++ b/commands/open.py
@@ -76,28 +76,33 @@ def print_rewrite_confirmation_message(commit_path, docx_path=None):
 
 
 def main():
-    if __name__ == "__main__":
-        utils.check_sccs_layout()
+    utils.check_sccs_layout()
 
-        commit_path = get_commit_path_input()
+    commit_path = get_commit_path_input()
 
-        check_commit_path_input(commit_path)
+    check_commit_path_input(commit_path)
 
-        check_changes(commit_path)
+    check_changes(commit_path)
 
-        confirm_before_proceeding(commit_path)
+    confirm_before_proceeding(commit_path)
 
-        copy_file_commit(commit_path)
+    copy_file_commit(commit_path)
 
-        print_rewrite_confirmation_message(commit_path)
-    else:
-        raise exceptions.FileImportedAsModuleError(
-            "This file cannot be run as a module. Please run it as a script."
-        )
+    print_rewrite_confirmation_message(commit_path)
 
 
-try:
-    main()
-except Exception as e:
-    print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
-    raise exceptions.SCCSException
+if __name__ == "__main__":
+    try:
+        main()
+
+    except exceptions.SCCSException as e:
+        print(f"An error occurred:\n{e}\n")
+        sys.exit(1)
+
+    except Exception as e:
+        print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
+        sys.exit(2)
+else:
+    raise exceptions.FileImportedAsModuleError(
+        "This file cannot be run as a module. Please run it as a script."
+    )

--- a/commands/open.py
+++ b/commands/open.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 
 import utils
+import exceptions
 
 
 def get_commit_path_input():

--- a/commands/open.py
+++ b/commands/open.py
@@ -63,7 +63,7 @@ def copy_file_commit(commit_path, docx_path=None):
     try:
         shutil.copy2(commit_path, docx_path)
     except Exception as e:
-        raise exceptions.FileCopyError(f"Error copying file: {e}")
+        raise exceptions.FileCopyError from e
 
 
 def print_rewrite_confirmation_message(commit_path, docx_path=None):

--- a/commands/open.py
+++ b/commands/open.py
@@ -17,7 +17,7 @@ def check_commit_path_input(commit_path):
         raise exceptions.InvalidArgumentError("Commit file path cannot be empty.")
 
     if not Path(commit_path).is_file():
-        raise exceptions.InvalidArgumentError("Commit file does not exist.")
+        raise FileNotFoundError("Commit file does not exist.")
 
     if Path(commit_path).suffix.lower() != ".docx":
         raise exceptions.InvalidFileTypeError("Commit file is not a .docx file.")

--- a/commands/open.py
+++ b/commands/open.py
@@ -75,17 +75,29 @@ def print_rewrite_confirmation_message(commit_path, docx_path=None):
     )
 
 
-if __name__ == "__main__":
-    utils.check_sccs_layout()
+def main():
+    if __name__ == "__main__":
+        utils.check_sccs_layout()
 
-    commit_path = get_commit_path_input()
+        commit_path = get_commit_path_input()
 
-    check_commit_path_input(commit_path)
+        check_commit_path_input(commit_path)
 
-    check_changes(commit_path)
+        check_changes(commit_path)
 
-    confirm_before_proceeding(commit_path)
+        confirm_before_proceeding(commit_path)
 
-    copy_file_commit(commit_path)
+        copy_file_commit(commit_path)
 
-    print_rewrite_confirmation_message(commit_path)
+        print_rewrite_confirmation_message(commit_path)
+    else:
+        raise exceptions.FileImportedAsModuleError(
+            "This file cannot be run as a module. Please run it as a script."
+        )
+
+
+try:
+    main()
+except Exception as e:
+    print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
+    raise exceptions.SCCSException

--- a/commands/open.py
+++ b/commands/open.py
@@ -14,12 +14,13 @@ def get_commit_path_input():
 
 def check_commit_path_input(commit_path):
     if commit_path == "":
-        print("Commit file path cannot be empty.")
-        sys.exit(1)
+        raise exceptions.InvalidArgumentError("Commit file path cannot be empty.")
 
-    if not Path(commit_path).is_file() or Path(commit_path).suffix.lower() != ".docx":
-        print("Invalid commit file path, make sure the file exists and is a .docx file")
-        sys.exit(1)
+    if not Path(commit_path).is_file():
+        raise exceptions.InvalidArgumentError("Commit file does not exist.")
+
+    if Path(commit_path).suffix.lower() != ".docx":
+        raise exceptions.InvalidFileTypeError("Commit file is not a .docx file.")
 
 
 def confirm_before_proceeding(commit_path, docx_path=None, cwd=None):
@@ -62,9 +63,7 @@ def copy_file_commit(commit_path, docx_path=None):
     try:
         shutil.copy2(commit_path, docx_path)
     except Exception as e:
-        print(f"Error occurred while updating the file: {e}")
-        sys.exit(1)
-
+        raise exceptions.FileCopyError(f"Error copying file: {e}")
 
 def print_rewrite_confirmation_message(commit_path, docx_path=None):
     if docx_path is None:

--- a/commands/open.py
+++ b/commands/open.py
@@ -3,8 +3,8 @@ import shutil
 import sys
 from pathlib import Path
 
-import utils
 import exceptions
+import utils
 
 
 def get_commit_path_input():
@@ -64,6 +64,7 @@ def copy_file_commit(commit_path, docx_path=None):
         shutil.copy2(commit_path, docx_path)
     except Exception as e:
         raise exceptions.FileCopyError(f"Error copying file: {e}")
+
 
 def print_rewrite_confirmation_message(commit_path, docx_path=None):
     if docx_path is None:

--- a/commands/sccs
+++ b/commands/sccs
@@ -21,20 +21,14 @@ COMMANDS = [
 def get_entered_command():
     return sys.argv[1] if len(sys.argv) > 1 else None
 
+
 def get_script_directory():
     return os.path.dirname(os.path.realpath(__file__))
+
 
 def check_if_command_is_valid(command, COMMANDS):
     return command in COMMANDS
 
-def print_unknown_command_error(command):
-    print(f"Unknown command: {command}")
-    print(
-        "Invalid command. Please use 'init', 'commit', 'open', 'log', 'diff', 'status"
-        "', 'help', 'branch', or 'switch', along with required arguments."
-    )
-    print("For help, use the 'sccs help' command.")
-    raise exceptions.UnknownCommandError(f"Unknown command: {command}. Please use 'init', 'commit', 'open', 'log', 'diff', 'status', 'help', 'branch', or 'switch', along with required arguments.")
 
 def run_command(command, script_directory):
     sys.exit(
@@ -45,10 +39,12 @@ def run_command(command, script_directory):
         ).returncode
     )
 
+
 def execute_command(command, script_directory, COMMANDS):
     if not check_if_command_is_valid(command, COMMANDS):
-        print_unknown_command_error(command)
+        raise exceptions.UnknownCommandError(f"Unknown command: {command}. Please use 'init', 'commit', 'open', 'log', 'diff', 'status', 'help', 'branch', or 'switch', along with required arguments. For help, use the 'sccs help' command.")
     run_command(command, script_directory)
+
 
 if __name__ == "__main__":
 

--- a/commands/sccs
+++ b/commands/sccs
@@ -26,10 +26,6 @@ def get_script_directory():
     return os.path.dirname(os.path.realpath(__file__))
 
 
-def check_if_command_is_valid(command, COMMANDS):
-    return command in COMMANDS
-
-
 def run_command(command, script_directory):
     sys.exit(
         subprocess.run([
@@ -41,7 +37,7 @@ def run_command(command, script_directory):
 
 
 def execute_command(command, script_directory, COMMANDS):
-    if not check_if_command_is_valid(command, COMMANDS):
+    if command not in COMMANDS:
         raise exceptions.UnknownCommandError(f"Unknown command: {command}. Please use 'init', 'commit', 'open', 'log', 'diff', 'status', 'help', 'branch', or 'switch', along with required arguments. For help, use the 'sccs help' command.")
     run_command(command, script_directory)
 

--- a/commands/sccs
+++ b/commands/sccs
@@ -47,24 +47,28 @@ def execute_command(command, script_directory, COMMANDS):
 
 
 def main():
-    if __name__ == "__main__":
+    command = get_entered_command()
 
-        command = get_entered_command()
+    script_directory = get_script_directory()
 
-        script_directory = get_script_directory()
-
-        execute_command(command, script_directory, COMMANDS)
-    else:
-        raise exceptions.FileImportedAsModuleError(
-            "This file cannot be run as a module. Please run it as a script."
-        )
+    execute_command(command, script_directory, COMMANDS)
 
 
-try:
-    main()
-except Exception as e:
-    print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
-    raise exceptions.SCCSException
+if __name__ == "__main__":
+    try:
+        main()
+
+    except exceptions.SCCSException as e:
+        print(f"An error occurred:\n{e}\n")
+        sys.exit(1)
+
+    except Exception as e:
+        print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
+        sys.exit(2)
+else:
+    raise exceptions.FileImportedAsModuleError(
+        "This file cannot be run as a module. Please run it as a script."
+    )
 
 # If on MacOS / Linux, move this file, commit.py, init.py, open.py, log.py, diff.py,
 # status.py, help.py, branch.py , and switch.py to /usr/local/bin and make it executable

--- a/commands/sccs
+++ b/commands/sccs
@@ -46,13 +46,25 @@ def execute_command(command, script_directory, COMMANDS):
     run_command(command, script_directory)
 
 
-if __name__ == "__main__":
+def main():
+    if __name__ == "__main__":
 
-    command = get_entered_command()
+        command = get_entered_command()
 
-    script_directory = get_script_directory()
-    
-    execute_command(command, script_directory, COMMANDS)
+        script_directory = get_script_directory()
+
+        execute_command(command, script_directory, COMMANDS)
+    else:
+        raise exceptions.FileImportedAsModuleError(
+            "This file cannot be run as a module. Please run it as a script."
+        )
+
+
+try:
+    main()
+except Exception as e:
+    print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
+    raise exceptions.SCCSException
 
 # If on MacOS / Linux, move this file, commit.py, init.py, open.py, log.py, diff.py,
 # status.py, help.py, branch.py , and switch.py to /usr/local/bin and make it executable

--- a/commands/sccs
+++ b/commands/sccs
@@ -38,7 +38,11 @@ def run_command(command, script_directory):
 
 def execute_command(command, script_directory, COMMANDS):
     if command not in COMMANDS:
-        raise exceptions.UnknownCommandError(f"Unknown command: {command}. Please use 'init', 'commit', 'open', 'log', 'diff', 'status', 'help', 'branch', or 'switch', along with required arguments. For help, use the 'sccs help' command.")
+        raise exceptions.UnknownCommandError(
+            f"Unknown command: {command}. Please use 'init', 'commit', 'open', 'log', "
+            f"'diff', 'status', 'help', 'branch', or 'switch', along with required "
+            f"arguments. For help, use the 'sccs help' command."
+        )
     run_command(command, script_directory)
 
 

--- a/commands/sccs
+++ b/commands/sccs
@@ -34,7 +34,7 @@ def print_unknown_command_error(command):
         "', 'help', 'branch', or 'switch', along with required arguments."
     )
     print("For help, use the 'sccs help' command.")
-    raise exceptions.UnknownCommandError(f"Unknown command: {command}""Invalid command. Please use 'init', 'commit', 'open', 'log', 'diff', 'status', 'help', 'branch', or 'switch', along with required arguments.")
+    raise exceptions.UnknownCommandError(f"Unknown command: {command}. Please use 'init', 'commit', 'open', 'log', 'diff', 'status', 'help', 'branch', or 'switch', along with required arguments.")
 
 def run_command(command, script_directory):
     sys.exit(

--- a/commands/sccs
+++ b/commands/sccs
@@ -3,6 +3,8 @@ import os
 import subprocess
 import sys
 
+import exceptions
+
 COMMANDS = [
     "init",
     "commit",
@@ -32,7 +34,7 @@ def print_unknown_command_error(command):
         "', 'help', 'branch', or 'switch', along with required arguments."
     )
     print("For help, use the 'sccs help' command.")
-    sys.exit(1)
+    raise exceptions.UnknownCommandError(f"Unknown command: {command}""Invalid command. Please use 'init', 'commit', 'open', 'log', 'diff', 'status', 'help', 'branch', or 'switch', along with required arguments.")
 
 def run_command(command, script_directory):
     sys.exit(

--- a/commands/status.py
+++ b/commands/status.py
@@ -31,7 +31,7 @@ def get_latest_commit_hash_file(current_branch, cwd=None):
             latest_commit_hash = history["history"]["latest_commit"]
 
     except Exception as e:
-        raise exceptions.FileOpenError(f"Error retrieving JSON from history file: {e}")
+        raise exceptions.FileOpenError from e
 
     if not latest_commit_hash:
         raise exceptions.InvalidMetadataError(
@@ -77,7 +77,7 @@ def get_latest_commit_file_binary_hash(current_branch=None, cwd=None):
             )
 
     except Exception as e:
-        raise exceptions.FileOpenError(f"Error reading latest commit file hash: {e}")
+        raise exceptions.FileOpenError from e
 
     return latest_commit_file_hash
 

--- a/commands/status.py
+++ b/commands/status.py
@@ -20,7 +20,7 @@ def get_latest_commit_hash_file(current_branch, cwd=None):
             "History file not found. Please run 'sccs init <file_path>' to initialize "
             "SCCS for this file."
         )
-        raise exceptions.FileNotFoundError("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise FileNotFoundError("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     try:
         with open(history_path, "r", encoding="utf-8", newline="\n") as history_file:

--- a/commands/status.py
+++ b/commands/status.py
@@ -86,7 +86,7 @@ def compare_hashes(old_hash, new_hash):
     return old_hash == new_hash
 
 
-def print_changes_message_and_exit(old_hash, new_hash):
+def compare_changes_and_exit(old_hash, new_hash):
     if compare_hashes(old_hash, new_hash):
         print("No changes detected since the latest commit. Nothing to commit.")
         sys.exit(0)
@@ -99,6 +99,6 @@ def print_changes_message_and_exit(old_hash, new_hash):
 
 if __name__ == "__main__":
     utils.check_sccs_layout()
-    print_changes_message_and_exit(
+    compare_changes_and_exit(
         get_latest_commit_file_binary_hash(), utils.hash_current_docx_binary()
     )

--- a/commands/status.py
+++ b/commands/status.py
@@ -98,19 +98,24 @@ def compare_changes_and_exit(old_hash, new_hash):
 
 
 def main():
-    if __name__ == "__main__":
-        utils.check_sccs_layout()
-        compare_changes_and_exit(
-            get_latest_commit_file_binary_hash(), utils.hash_current_docx_binary()
-        )
-    else:
-        raise exceptions.FileImportedAsModuleError(
-            "This file cannot be run as a module. Please run it as a script."
-        )
+    utils.check_sccs_layout()
+    compare_changes_and_exit(
+        get_latest_commit_file_binary_hash(), utils.hash_current_docx_binary()
+    )
 
 
-try:
-    main()
-except Exception as e:
-    print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
-    raise exceptions.SCCSException
+if __name__ == "__main__":
+    try:
+        main()
+
+    except exceptions.SCCSException as e:
+        print(f"An error occurred:\n{e}\n")
+        sys.exit(1)
+
+    except Exception as e:
+        print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
+        sys.exit(2)
+else:
+    raise exceptions.FileImportedAsModuleError(
+        "This file cannot be run as a module. Please run it as a script."
+    )

--- a/commands/status.py
+++ b/commands/status.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 
 import utils
+import exceptions
 
 
 def get_latest_commit_hash_file(current_branch, cwd=None):

--- a/commands/status.py
+++ b/commands/status.py
@@ -20,7 +20,7 @@ def get_latest_commit_hash_file(current_branch, cwd=None):
             "History file not found. Please run 'sccs init <file_path>' to initialize "
             "SCCS for this file."
         )
-        sys.exit(1)
+        raise exceptions.FileNotFoundError("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     try:
         with open(history_path, "r", encoding="utf-8", newline="\n") as history_file:
@@ -28,15 +28,11 @@ def get_latest_commit_hash_file(current_branch, cwd=None):
             latest_commit_hash = history["history"]["latest_commit"]
 
     except Exception as e:
-        print(f"Error loading history file: {e}")
-        sys.exit(1)
+        raise exceptions.FileOpenError(f"Error retrieving JSON from history file: {e}")
+
 
     if not latest_commit_hash:
-        print(
-            "History file is missing the latest commit information. Please "
-            "reinitialize SCCS for this file."
-        )
-        sys.exit(1)
+        raise exceptions.InvalidMetadataError("History file is missing the latest commit information. Please reinitialize SCCS for this file.")
 
     return latest_commit_hash
 
@@ -57,11 +53,7 @@ def get_latest_commit_file_binary_hash(current_branch=None, cwd=None):
         "commit_file_hash.json",
     )
     if not Path(latest_commit_file_hash_path).is_file():
-        print(
-            "Latest commit file hash not found. Please run 'sccs init <file_path>' to "
-            "initialize SCCS for this file."
-        )
-        sys.exit(1)
+        raise FileNotFoundError("Latest commit file hash not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     try:
         with open(
@@ -71,14 +63,12 @@ def get_latest_commit_file_binary_hash(current_branch=None, cwd=None):
             latest_commit_file_hash = commit_file_hash_data.get(latest_commit_hash)
 
         if not latest_commit_file_hash:
-            print(
-                "Latest commit file hash is missing from JSON. Please run 'sccs init "
-                "<file_path>' to initialize SCCS for this file."
-            )
-            sys.exit(1)
-    except (json.JSONDecodeError, KeyError, TypeError, OSError) as e:
-        print(f"Error reading latest commit file hash: {e}")
-        sys.exit(1)
+            raise exceptions.InvalidMetadataError("Latest commit file hash is missing from JSON. Please reinitialize SCCS for this file.")
+
+
+    except Exception as e:
+        raise exceptions.FileOpenError(f"Error reading latest commit file hash: {e}")
+        
 
     return latest_commit_file_hash
 
@@ -92,11 +82,7 @@ def print_changes_message_and_exit(old_hash, new_hash):
         print("No changes detected since the latest commit. Nothing to commit.")
         sys.exit(0)
     else:
-        print(
-            "Changes detected since the latest commit. You can proceed with committing "
-            "these changes."
-        )
-        sys.exit(1)
+        raise exceptions.UncommittedChangesError("Changes detected since the latest commit. You can proceed with committing these changes.")
 
 
 if __name__ == "__main__":

--- a/commands/status.py
+++ b/commands/status.py
@@ -4,8 +4,8 @@ import os
 import sys
 from pathlib import Path
 
-import utils
 import exceptions
+import utils
 
 
 def get_latest_commit_hash_file(current_branch, cwd=None):
@@ -20,7 +20,9 @@ def get_latest_commit_hash_file(current_branch, cwd=None):
             "History file not found. Please run 'sccs init <file_path>' to initialize "
             "SCCS for this file."
         )
-        raise FileNotFoundError("History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise FileNotFoundError(
+            "History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
 
     try:
         with open(history_path, "r", encoding="utf-8", newline="\n") as history_file:
@@ -30,9 +32,10 @@ def get_latest_commit_hash_file(current_branch, cwd=None):
     except Exception as e:
         raise exceptions.FileOpenError(f"Error retrieving JSON from history file: {e}")
 
-
     if not latest_commit_hash:
-        raise exceptions.InvalidMetadataError("History file is missing the latest commit information. Please reinitialize SCCS for this file.")
+        raise exceptions.InvalidMetadataError(
+            "History file is missing the latest commit information. Please reinitialize SCCS for this file."
+        )
 
     return latest_commit_hash
 
@@ -53,7 +56,9 @@ def get_latest_commit_file_binary_hash(current_branch=None, cwd=None):
         "commit_file_hash.json",
     )
     if not Path(latest_commit_file_hash_path).is_file():
-        raise FileNotFoundError("Latest commit file hash not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise FileNotFoundError(
+            "Latest commit file hash not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
 
     try:
         with open(
@@ -63,12 +68,12 @@ def get_latest_commit_file_binary_hash(current_branch=None, cwd=None):
             latest_commit_file_hash = commit_file_hash_data.get(latest_commit_hash)
 
         if not latest_commit_file_hash:
-            raise exceptions.InvalidMetadataError("Latest commit file hash is missing from JSON. Please reinitialize SCCS for this file.")
-
+            raise exceptions.InvalidMetadataError(
+                "Latest commit file hash is missing from JSON. Please reinitialize SCCS for this file."
+            )
 
     except Exception as e:
         raise exceptions.FileOpenError(f"Error reading latest commit file hash: {e}")
-        
 
     return latest_commit_file_hash
 
@@ -82,7 +87,9 @@ def print_changes_message_and_exit(old_hash, new_hash):
         print("No changes detected since the latest commit. Nothing to commit.")
         sys.exit(0)
     else:
-        raise exceptions.UncommittedChangesError("Changes detected since the latest commit. You can proceed with committing these changes.")
+        raise exceptions.UncommittedChangesError(
+            "Changes detected since the latest commit. You can proceed with committing these changes."
+        )
 
 
 if __name__ == "__main__":

--- a/commands/status.py
+++ b/commands/status.py
@@ -21,7 +21,8 @@ def get_latest_commit_hash_file(current_branch, cwd=None):
             "SCCS for this file."
         )
         raise FileNotFoundError(
-            "History file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "History file not found. Please run 'sccs init <file_path>' to initialize "
+            "SCCS for this file."
         )
 
     try:
@@ -34,7 +35,8 @@ def get_latest_commit_hash_file(current_branch, cwd=None):
 
     if not latest_commit_hash:
         raise exceptions.InvalidMetadataError(
-            "History file is missing the latest commit information. Please reinitialize SCCS for this file."
+            "History file is missing the latest commit information. Please reinitialize"
+            " SCCS for this file."
         )
 
     return latest_commit_hash
@@ -57,7 +59,8 @@ def get_latest_commit_file_binary_hash(current_branch=None, cwd=None):
     )
     if not Path(latest_commit_file_hash_path).is_file():
         raise FileNotFoundError(
-            "Latest commit file hash not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "Latest commit file hash not found. Please run 'sccs init <file_path>' to "
+            "initialize SCCS for this file."
         )
 
     try:
@@ -69,7 +72,8 @@ def get_latest_commit_file_binary_hash(current_branch=None, cwd=None):
 
         if not latest_commit_file_hash:
             raise exceptions.InvalidMetadataError(
-                "Latest commit file hash is missing from JSON. Please reinitialize SCCS for this file."
+                "Latest commit file hash is missing from JSON. Please reinitialize SCCS"
+                " for this file."
             )
 
     except Exception as e:
@@ -88,7 +92,8 @@ def print_changes_message_and_exit(old_hash, new_hash):
         sys.exit(0)
     else:
         raise exceptions.UncommittedChangesError(
-            "Changes detected since the latest commit. You can proceed with committing these changes."
+            "Changes detected since the latest commit. You can proceed with committing "
+            "these changes."
         )
 
 

--- a/commands/status.py
+++ b/commands/status.py
@@ -97,8 +97,20 @@ def compare_changes_and_exit(old_hash, new_hash):
         )
 
 
-if __name__ == "__main__":
-    utils.check_sccs_layout()
-    compare_changes_and_exit(
-        get_latest_commit_file_binary_hash(), utils.hash_current_docx_binary()
-    )
+def main():
+    if __name__ == "__main__":
+        utils.check_sccs_layout()
+        compare_changes_and_exit(
+            get_latest_commit_file_binary_hash(), utils.hash_current_docx_binary()
+        )
+    else:
+        raise exceptions.FileImportedAsModuleError(
+            "This file cannot be run as a module. Please run it as a script."
+        )
+
+
+try:
+    main()
+except Exception as e:
+    print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
+    raise exceptions.SCCSException

--- a/commands/switch.py
+++ b/commands/switch.py
@@ -126,48 +126,51 @@ def print_confirmation(branch_to_switch):
 
 
 def main():
-    if __name__ == "__main__":
-        utils.check_sccs_layout()
+    utils.check_sccs_layout()
 
-        branches = utils.get_branch_data(key="branches")
+    branches = utils.get_branch_data(key="branches")
 
-        current_branch = utils.get_current_branch()
+    current_branch = utils.get_current_branch()
 
-        latest_commit = get_latest_commit(current_branch)
+    latest_commit = get_latest_commit(current_branch)
 
-        latest_commit_binary_hash = get_latest_commit_binary_hash(
-            current_branch, latest_commit
-        )
+    latest_commit_binary_hash = get_latest_commit_binary_hash(
+        current_branch, latest_commit
+    )
 
-        current_document_hash = utils.hash_current_docx_binary()
+    current_document_hash = utils.hash_current_docx_binary()
 
-        check_for_changes(
-            current_branch, latest_commit_binary_hash, current_document_hash
-        )
+    check_for_changes(current_branch, latest_commit_binary_hash, current_document_hash)
 
-        branch_to_switch = get_branch_to_switch()
+    branch_to_switch = get_branch_to_switch()
 
-        check_branch_to_switch(branch_to_switch, branches)
+    check_branch_to_switch(branch_to_switch, branches)
 
-        branch_to_switch = sanitize_branch(branch_to_switch)
+    branch_to_switch = sanitize_branch(branch_to_switch)
 
-        latest_commit_on_branch_to_switch = get_latest_commit(branch_to_switch)
+    latest_commit_on_branch_to_switch = get_latest_commit(branch_to_switch)
 
-        check_commit(latest_commit_on_branch_to_switch)
+    check_commit(latest_commit_on_branch_to_switch)
 
-        copy_commit_to_main(latest_commit_on_branch_to_switch)
+    copy_commit_to_main(latest_commit_on_branch_to_switch)
 
-        update_current_branch(branch_to_switch)
+    update_current_branch(branch_to_switch)
 
-        print_confirmation(branch_to_switch)
-    else:
-        raise exceptions.FileImportedAsModuleError(
-            "This file cannot be run as a module. Please run it as a script."
-        )
+    print_confirmation(branch_to_switch)
 
 
-try:
-    main()
-except Exception as e:
-    print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
-    raise exceptions.SCCSException
+if __name__ == "__main__":
+    try:
+        main()
+
+    except exceptions.SCCSException as e:
+        print(f"An error occurred:\n{e}\n")
+        sys.exit(1)
+
+    except Exception as e:
+        print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
+        sys.exit(2)
+else:
+    raise exceptions.FileImportedAsModuleError(
+        "This file cannot be run as a module. Please run it as a script."
+    )

--- a/commands/switch.py
+++ b/commands/switch.py
@@ -33,9 +33,7 @@ def update_current_branch(branch, current_branch_path=None, cwd=None):
         )
 
     except Exception as e:
-        raise exceptions.UpdatingMetadataError(
-            f"Error updating current branch information: {e}"
-        )
+        raise exceptions.UpdatingMetadataError from e
 
 
 def check_branch_to_switch(branch_to_switch, branches):
@@ -69,8 +67,7 @@ def get_latest_commit_binary_hash(branch, latest_commit, cwd=None):
         ) as f:
             return json.load(f).get(latest_commit)
     except Exception as e:
-        raise exceptions.FileOpenError(f"Error reading commit file hash: {e}")
-
+        raise exceptions.FileOpenError from e
 
 def check_for_changes(branch, latest_commit_binary_hash, current_document_hash):
     if not current_document_hash == latest_commit_binary_hash:
@@ -99,9 +96,7 @@ def get_latest_commit(branch, cwd=None):
             history = json.load(f)
             return history["history"]["latest_commit"]
     except Exception as e:
-        raise exceptions.FileOpenError(
-            f"Error reading commit history for branch '{branch}': {e}"
-        )
+        raise exceptions.FileOpenError from e 
 
 
 def check_commit(commit, cwd=None):
@@ -122,7 +117,7 @@ def copy_commit_to_main(commit, cwd=None):
             os.path.join(cwd, f"{os.path.basename(cwd)}.docx"),
         )
     except Exception as e:
-        raise exceptions.FileCopyError(f"Error copying commit '{commit}' to main: {e}")
+        raise exceptions.FileCopyError from e
 
 
 def print_confirmation(branch_to_switch):

--- a/commands/switch.py
+++ b/commands/switch.py
@@ -5,6 +5,7 @@ import shutil
 import sys
 
 import utils
+import exceptions
 
 
 def get_branch_to_switch():

--- a/commands/switch.py
+++ b/commands/switch.py
@@ -33,18 +33,20 @@ def update_current_branch(branch, current_branch_path=None, cwd=None):
         )
 
     except Exception as e:
-        print(f"Error updating current branch information: {e}")
-        sys.exit(1)
+        raise exceptions.UpdatingMetadataError(f"Error updating current branch information: {e}")
+
+
 
 
 def check_branch_to_switch(branch_to_switch, branches):
-    if not branch_to_switch or len(branch_to_switch) == 0:
-        print("No branch specified. Please provide a branch name to switch to.")
-        sys.exit(1)
+    if not branch_to_switch:
+        raise exceptions.InvalidArgumentError("No branch specified. Please provide a branch name to switch to.")
+
 
     if branch_to_switch not in branches:
-        print(f"Error: Branch '{branch_to_switch}' does not exist.")
-        sys.exit(1)
+        raise exceptions.BranchDoesNotExistError(f"Branch '{branch_to_switch}' does not exist.")
+
+
 
 
 def get_latest_commit_binary_hash(branch, latest_commit, cwd=None):
@@ -66,18 +68,14 @@ def get_latest_commit_binary_hash(branch, latest_commit, cwd=None):
         ) as f:
             return json.load(f).get(latest_commit)
     except Exception as e:
-        print(f"Error accessing commit file hash for branch '{branch}': {e}")
-        sys.exit(1)
+        raise exceptions.FileOpenError(f"Error reading commit file hash: {e}")
+
+
 
 
 def check_for_changes(branch, latest_commit_binary_hash, current_document_hash):
     if not current_document_hash == latest_commit_binary_hash:
-        print(
-            f"Error: The current file has uncommitted changes on the current branch "
-            f"'{branch}'. Please commit your changes before switching branches."
-        )
-        sys.exit(1)
-
+        raise exceptions.UncommittedChangesError(f"The current file has uncommitted changes on the current branch '{branch}'. Please commit your changes before switching branches.")
 
 def sanitize_branch(branch_name):
     return utils.clean_directory_name(branch_name)
@@ -98,9 +96,7 @@ def get_latest_commit(branch, cwd=None):
             history = json.load(f)
             return history["history"]["latest_commit"]
     except Exception as e:
-        print(f"Error reading commit history for branch '{branch}': {e}")
-        sys.exit(1)
-
+        raise exceptions.FileOpenError(f"Error reading commit history for branch '{branch}': {e}")
 
 def check_commit(commit, cwd=None):
     if cwd is None:
@@ -108,8 +104,8 @@ def check_commit(commit, cwd=None):
     if not os.path.isfile(
         os.path.join(cwd, ".sccs", "objects", "docx", f"{commit}.docx")
     ):
-        print(f"Error: Commit object '{commit}' not found.")
-        sys.exit(1)
+        raise exceptions.CommitNotFoundError(f"Commit object '{commit}' not found.")
+
 
 
 def copy_commit_to_main(commit, cwd=None):
@@ -121,8 +117,9 @@ def copy_commit_to_main(commit, cwd=None):
             os.path.join(cwd, f"{os.path.basename(cwd)}.docx"),
         )
     except Exception as e:
-        print(f"Error copying commit '{commit}' to main: {e}")
-        sys.exit(1)
+        raise exceptions.FileCopyError(f"Error copying commit '{commit}' to main: {e}")
+
+
 
 
 def print_confirmation(branch_to_switch):

--- a/commands/switch.py
+++ b/commands/switch.py
@@ -69,6 +69,7 @@ def get_latest_commit_binary_hash(branch, latest_commit, cwd=None):
     except Exception as e:
         raise exceptions.FileOpenError from e
 
+
 def check_for_changes(branch, latest_commit_binary_hash, current_document_hash):
     if not current_document_hash == latest_commit_binary_hash:
         raise exceptions.UncommittedChangesError(
@@ -96,7 +97,7 @@ def get_latest_commit(branch, cwd=None):
             history = json.load(f)
             return history["history"]["latest_commit"]
     except Exception as e:
-        raise exceptions.FileOpenError from e 
+        raise exceptions.FileOpenError from e
 
 
 def check_commit(commit, cwd=None):

--- a/commands/switch.py
+++ b/commands/switch.py
@@ -4,8 +4,8 @@ import os
 import shutil
 import sys
 
-import utils
 import exceptions
+import utils
 
 
 def get_branch_to_switch():
@@ -33,20 +33,21 @@ def update_current_branch(branch, current_branch_path=None, cwd=None):
         )
 
     except Exception as e:
-        raise exceptions.UpdatingMetadataError(f"Error updating current branch information: {e}")
-
-
+        raise exceptions.UpdatingMetadataError(
+            f"Error updating current branch information: {e}"
+        )
 
 
 def check_branch_to_switch(branch_to_switch, branches):
     if not branch_to_switch:
-        raise exceptions.InvalidArgumentError("No branch specified. Please provide a branch name to switch to.")
-
+        raise exceptions.InvalidArgumentError(
+            "No branch specified. Please provide a branch name to switch to."
+        )
 
     if branch_to_switch not in branches:
-        raise exceptions.BranchNotFoundError(f"Branch '{branch_to_switch}' does not exist.")
-
-
+        raise exceptions.BranchNotFoundError(
+            f"Branch '{branch_to_switch}' does not exist."
+        )
 
 
 def get_latest_commit_binary_hash(branch, latest_commit, cwd=None):
@@ -71,11 +72,12 @@ def get_latest_commit_binary_hash(branch, latest_commit, cwd=None):
         raise exceptions.FileOpenError(f"Error reading commit file hash: {e}")
 
 
-
-
 def check_for_changes(branch, latest_commit_binary_hash, current_document_hash):
     if not current_document_hash == latest_commit_binary_hash:
-        raise exceptions.UncommittedChangesError(f"The current file has uncommitted changes on the current branch '{branch}'. Please commit your changes before switching branches.")
+        raise exceptions.UncommittedChangesError(
+            f"The current file has uncommitted changes on the current branch '{branch}'. Please commit your changes before switching branches."
+        )
+
 
 def sanitize_branch(branch_name):
     return utils.clean_directory_name(branch_name)
@@ -96,7 +98,10 @@ def get_latest_commit(branch, cwd=None):
             history = json.load(f)
             return history["history"]["latest_commit"]
     except Exception as e:
-        raise exceptions.FileOpenError(f"Error reading commit history for branch '{branch}': {e}")
+        raise exceptions.FileOpenError(
+            f"Error reading commit history for branch '{branch}': {e}"
+        )
+
 
 def check_commit(commit, cwd=None):
     if cwd is None:
@@ -105,7 +110,6 @@ def check_commit(commit, cwd=None):
         os.path.join(cwd, ".sccs", "objects", "docx", f"{commit}.docx")
     ):
         raise exceptions.CommitNotFoundError(f"Commit object '{commit}' not found.")
-
 
 
 def copy_commit_to_main(commit, cwd=None):
@@ -118,8 +122,6 @@ def copy_commit_to_main(commit, cwd=None):
         )
     except Exception as e:
         raise exceptions.FileCopyError(f"Error copying commit '{commit}' to main: {e}")
-
-
 
 
 def print_confirmation(branch_to_switch):

--- a/commands/switch.py
+++ b/commands/switch.py
@@ -125,35 +125,49 @@ def print_confirmation(branch_to_switch):
     print(f"Successfully switched to branch '{branch_to_switch}'.")
 
 
-if __name__ == "__main__":
-    utils.check_sccs_layout()
+def main():
+    if __name__ == "__main__":
+        utils.check_sccs_layout()
 
-    branches = utils.get_branch_data(key="branches")
+        branches = utils.get_branch_data(key="branches")
 
-    current_branch = utils.get_current_branch()
+        current_branch = utils.get_current_branch()
 
-    latest_commit = get_latest_commit(current_branch)
+        latest_commit = get_latest_commit(current_branch)
 
-    latest_commit_binary_hash = get_latest_commit_binary_hash(
-        current_branch, latest_commit
-    )
+        latest_commit_binary_hash = get_latest_commit_binary_hash(
+            current_branch, latest_commit
+        )
 
-    current_document_hash = utils.hash_current_docx_binary()
+        current_document_hash = utils.hash_current_docx_binary()
 
-    check_for_changes(current_branch, latest_commit_binary_hash, current_document_hash)
+        check_for_changes(
+            current_branch, latest_commit_binary_hash, current_document_hash
+        )
 
-    branch_to_switch = get_branch_to_switch()
+        branch_to_switch = get_branch_to_switch()
 
-    check_branch_to_switch(branch_to_switch, branches)
+        check_branch_to_switch(branch_to_switch, branches)
 
-    branch_to_switch = sanitize_branch(branch_to_switch)
+        branch_to_switch = sanitize_branch(branch_to_switch)
 
-    latest_commit_on_branch_to_switch = get_latest_commit(branch_to_switch)
+        latest_commit_on_branch_to_switch = get_latest_commit(branch_to_switch)
 
-    check_commit(latest_commit_on_branch_to_switch)
+        check_commit(latest_commit_on_branch_to_switch)
 
-    copy_commit_to_main(latest_commit_on_branch_to_switch)
+        copy_commit_to_main(latest_commit_on_branch_to_switch)
 
-    update_current_branch(branch_to_switch)
+        update_current_branch(branch_to_switch)
 
-    print_confirmation(branch_to_switch)
+        print_confirmation(branch_to_switch)
+    else:
+        raise exceptions.FileImportedAsModuleError(
+            "This file cannot be run as a module. Please run it as a script."
+        )
+
+
+try:
+    main()
+except Exception as e:
+    print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
+    raise exceptions.SCCSException

--- a/commands/switch.py
+++ b/commands/switch.py
@@ -75,7 +75,8 @@ def get_latest_commit_binary_hash(branch, latest_commit, cwd=None):
 def check_for_changes(branch, latest_commit_binary_hash, current_document_hash):
     if not current_document_hash == latest_commit_binary_hash:
         raise exceptions.UncommittedChangesError(
-            f"The current file has uncommitted changes on the current branch '{branch}'. Please commit your changes before switching branches."
+            f"The current file has uncommitted changes on the current branch '{branch}'"
+            f". Please commit your changes before switching branches."
         )
 
 

--- a/commands/switch.py
+++ b/commands/switch.py
@@ -44,7 +44,7 @@ def check_branch_to_switch(branch_to_switch, branches):
 
 
     if branch_to_switch not in branches:
-        raise exceptions.BranchDoesNotExistError(f"Branch '{branch_to_switch}' does not exist.")
+        raise exceptions.BranchNotFoundError(f"Branch '{branch_to_switch}' does not exist.")
 
 
 

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -73,10 +73,10 @@ def check_sccs_layout(
                 )
 
     except (json.JSONDecodeError, KeyError, TypeError, OSError) as e:
-        raise exceptions.BranchNotFoundError(
+        raise exceptions.InvalidMetadataError(
             "Current branch file is missing or corrupted. Please run 'sccs init "
             "<file_path>' to initialize SCCS for this file."
-        )
+        ) from e
 
     if not Path(os.path.join(sccs_dir, "branches", current_branch)).is_dir():
         raise exceptions.BranchNotFoundError(

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -194,8 +194,7 @@ def hash_current_docx_binary(docx_path=current_file_docx_path):
                 hasher.update(chunk)
             hashed_file = hasher.hexdigest()
     except Exception as e:
-        raise exceptions.DocumentHashingError(f"Error processing .docx file: {e}")
-
+        raise exceptions.DocumentHashingError from e
     return hashed_file
 
 
@@ -211,7 +210,7 @@ def get_current_branch(file_path=current_branch_path):
                     "<file_path>' to initialize SCCS for this file."
                 )
     except Exception as e:
-        raise exceptions.FileOpenError(f"Error reading current branch: {e}")
+        raise exceptions.FileOpenError from e 
 
     return current_branch
 
@@ -225,7 +224,7 @@ def get_branch_data(file_path=current_branch_path, key=None):
             return data
 
     except Exception as e:
-        raise exceptions.FileOpenError(f"Error reading current branch data: {e}")
+        raise exceptions.FileOpenError from e
 
 
 def convert_docx_to_html(docx_path=None):
@@ -236,6 +235,4 @@ def convert_docx_to_html(docx_path=None):
             result = mammoth.convert_to_html(f)
             return result.value
     except Exception as e:
-        raise exceptions.ConvertingDocumentToHTMLError(
-            f"Error converting .docx to HTML: {e}"
-        )
+        raise exceptions.ConvertingDocumentToHTMLError from e

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -67,7 +67,7 @@ def check_sccs_layout(
         ) as current_branch_file:
             current_branch = json.load(current_branch_file).get("current_branch")
             if not current_branch:
-                raise exceptions.BranchNotFoundError(
+                raise exceptions.InvalidMetadataError(
                     "Current branch not found. Please run 'sccs init <file_path>' to "
                     "initialize SCCS for this file."
                 )

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 import mammoth
+import exceptions
 
 working_directory_path = os.getcwd()
 

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -40,19 +40,22 @@ def check_sccs_layout(
 
     if not Path(sccs_dir).is_dir():
         raise exceptions.SCCSNotInitializedError(
-            "This file has not been initialized with SCCS.\nPlease run 'sccs init <file_path>' to initialize SCCS for this file."
+            "This file has not been initialized with SCCS.\nPlease run 'sccs init "
+            "<file_path>' to initialize SCCS for this file."
         )
 
     if not Path(os.path.join(sccs_dir, "current_branch")).is_dir():
         raise exceptions.BranchNotFoundError(
-            "Current branch directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "Current branch directory not found. Please run 'sccs init <file_path>' to "
+            "initialize SCCS for this file."
         )
 
     if not Path(
         os.path.join(sccs_dir, "current_branch", "current_branch.json")
     ).is_file():
         raise exceptions.BranchNotFoundError(
-            "Current branch file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "Current branch file not found. Please run 'sccs init <file_path>' to "
+            "initialize SCCS for this file."
         )
 
     try:
@@ -65,24 +68,28 @@ def check_sccs_layout(
             current_branch = json.load(current_branch_file).get("current_branch")
             if not current_branch:
                 raise exceptions.BranchNotFoundError(
-                    "Current branch not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+                    "Current branch not found. Please run 'sccs init <file_path>' to "
+                    "initialize SCCS for this file."
                 )
 
     except (json.JSONDecodeError, KeyError, TypeError, OSError) as e:
         raise exceptions.BranchNotFoundError(
-            "Current branch file is missing or corrupted. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "Current branch file is missing or corrupted. Please run 'sccs init "
+            "<file_path>' to initialize SCCS for this file."
         )
 
     if not Path(os.path.join(sccs_dir, "branches", current_branch)).is_dir():
         raise exceptions.BranchNotFoundError(
-            "Branch directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "Branch directory not found. Please run 'sccs init <file_path>' to "
+            "initialize SCCS for this file."
         )
 
     if not Path(
         os.path.join(sccs_dir, "branches", current_branch, "commit_file_hash")
     ).is_dir():
         raise FileNotFoundError(
-            "Commit file hash directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "Commit file hash directory not found. Please run 'sccs init <file_path>' "
+            "to initialize SCCS for this file."
         )
     if not Path(
         os.path.join(
@@ -94,55 +101,65 @@ def check_sccs_layout(
         )
     ).is_file():
         raise FileNotFoundError(
-            "Commit file hash JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "Commit file hash JSON not found. Please run 'sccs init <file_path>' to "
+            "initialize SCCS for this file."
         )
 
     if not Path(os.path.join(sccs_dir, "commit_messages")).is_dir():
         raise FileNotFoundError(
-            "Commit messages directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "Commit messages directory not found. Please run 'sccs init <file_path>' to"
+            " initialize SCCS for this file."
         )
 
     if not Path(
         os.path.join(sccs_dir, "commit_messages", "commit_messages.json")
     ).is_file():
         raise FileNotFoundError(
-            "Commit messages JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "Commit messages JSON not found. Please run 'sccs init <file_path>' to "
+            "initialize SCCS for this file."
         )
 
     if not Path(os.path.join(sccs_dir, "objects")).is_dir():
 
         raise FileNotFoundError(
-            "Objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "Objects directory not found. Please run 'sccs init <file_path>' to "
+            "initialize SCCS for this file."
         )
 
     if not Path(os.path.join(sccs_dir, "objects", "docx")).is_dir():
         raise FileNotFoundError(
-            "Docx objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "Docx objects directory not found. Please run 'sccs init <file_path>' to "
+            "initialize SCCS for this file."
         )
 
     if not Path(os.path.join(sccs_dir, "objects", "html")).is_dir():
         raise FileNotFoundError(
-            "HTML objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "HTML objects directory not found. Please run 'sccs init <file_path>' to "
+            "initialize SCCS for this file."
         )
 
     if not Path(os.path.join(sccs_dir, "objects", "view_html")).is_dir():
         raise FileNotFoundError(
-            "View HTML objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "View HTML objects directory not found. Please run 'sccs init <file_path>' "
+            "to initialize SCCS for this file."
         )
 
     if not Path(os.path.join(sccs_dir, "config")).is_dir():
         raise FileNotFoundError(
-            "Config directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "Config directory not found. Please run 'sccs init <file_path>' to "
+            "initialize SCCS for this file."
         )
 
     if not Path(os.path.join(sccs_dir, "config", "config.json")).is_file():
         raise FileNotFoundError(
-            "Config file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "Config file not found. Please run 'sccs init <file_path>' to "
+            "initialize SCCS for this file."
         )
 
     if not Path(os.path.join(sccs_dir, "branches", current_branch, "history")).is_dir():
         raise FileNotFoundError(
-            "History directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "History directory not found. Please run 'sccs init <file_path>' to "
+            "initialize SCCS for this file."
         )
 
     if not Path(
@@ -151,12 +168,14 @@ def check_sccs_layout(
         )
     ).is_file():
         raise FileNotFoundError(
-            "Commit history JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+            "Commit history JSON not found. Please run 'sccs init <file_path>' to "
+            "initialize SCCS for this file."
         )
 
     if not Path(docx_path).is_file():
         raise FileNotFoundError(
-            "Docx file not found. Re-initialize SCCS for this file with 'sccs init <file_path>'"
+            "Docx file not found. Re-initialize SCCS for this file with 'sccs init "
+            "<file_path>'"
         )
 
 
@@ -188,7 +207,8 @@ def get_current_branch(file_path=current_branch_path):
             current_branch = json.load(current_branch_file).get("current_branch")
             if not current_branch:
                 raise exceptions.InvalidMetadataError(
-                    "Current branch is missing from JSON. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+                    "Current branch is missing from JSON. Please run 'sccs init "
+                    "<file_path>' to initialize SCCS for this file."
                 )
     except Exception as e:
         raise exceptions.FileOpenError(f"Error reading current branch: {e}")

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -5,8 +5,8 @@ import re
 import sys
 from pathlib import Path
 
-import mammoth
 import exceptions
+import mammoth
 
 working_directory_path = os.getcwd()
 
@@ -39,16 +39,21 @@ def check_sccs_layout(
 ):
 
     if not Path(sccs_dir).is_dir():
-        raise exceptions.SCCSNotInitializedError("This file has not been initialized with SCCS.\nPlease run 'sccs init <file_path>' to initialize SCCS for this file.")
-
+        raise exceptions.SCCSNotInitializedError(
+            "This file has not been initialized with SCCS.\nPlease run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
 
     if not Path(os.path.join(sccs_dir, "current_branch")).is_dir():
-        raise exceptions.BranchNotFoundError("Current branch directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise exceptions.BranchNotFoundError(
+            "Current branch directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
 
     if not Path(
         os.path.join(sccs_dir, "current_branch", "current_branch.json")
     ).is_file():
-        raise exceptions.BranchNotFoundError("Current branch file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise exceptions.BranchNotFoundError(
+            "Current branch file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
 
     try:
         with open(
@@ -59,18 +64,26 @@ def check_sccs_layout(
         ) as current_branch_file:
             current_branch = json.load(current_branch_file).get("current_branch")
             if not current_branch:
-                raise exceptions.BranchNotFoundError("Current branch not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+                raise exceptions.BranchNotFoundError(
+                    "Current branch not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+                )
 
     except (json.JSONDecodeError, KeyError, TypeError, OSError) as e:
-        raise exceptions.BranchNotFoundError("Current branch file is missing or corrupted. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise exceptions.BranchNotFoundError(
+            "Current branch file is missing or corrupted. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
 
     if not Path(os.path.join(sccs_dir, "branches", current_branch)).is_dir():
-        raise exceptions.BranchNotFoundError("Branch directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise exceptions.BranchNotFoundError(
+            "Branch directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
 
     if not Path(
         os.path.join(sccs_dir, "branches", current_branch, "commit_file_hash")
     ).is_dir():
-        raise FileNotFoundError("Commit file hash directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise FileNotFoundError(
+            "Commit file hash directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
     if not Path(
         os.path.join(
             sccs_dir,
@@ -80,47 +93,72 @@ def check_sccs_layout(
             "commit_file_hash.json",
         )
     ).is_file():
-        raise FileNotFoundError("Commit file hash JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise FileNotFoundError(
+            "Commit file hash JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
 
     if not Path(os.path.join(sccs_dir, "commit_messages")).is_dir():
-        raise FileNotFoundError("Commit messages directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise FileNotFoundError(
+            "Commit messages directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
 
     if not Path(
         os.path.join(sccs_dir, "commit_messages", "commit_messages.json")
     ).is_file():
-        raise FileNotFoundError("Commit messages JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise FileNotFoundError(
+            "Commit messages JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
 
     if not Path(os.path.join(sccs_dir, "objects")).is_dir():
 
-        raise FileNotFoundError("Objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise FileNotFoundError(
+            "Objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
 
     if not Path(os.path.join(sccs_dir, "objects", "docx")).is_dir():
-        raise FileNotFoundError("Docx objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise FileNotFoundError(
+            "Docx objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
 
     if not Path(os.path.join(sccs_dir, "objects", "html")).is_dir():
-        raise FileNotFoundError("HTML objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise FileNotFoundError(
+            "HTML objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
 
     if not Path(os.path.join(sccs_dir, "objects", "view_html")).is_dir():
-        raise FileNotFoundError("View HTML objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise FileNotFoundError(
+            "View HTML objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
 
     if not Path(os.path.join(sccs_dir, "config")).is_dir():
-        raise FileNotFoundError("Config directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise FileNotFoundError(
+            "Config directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
 
     if not Path(os.path.join(sccs_dir, "config", "config.json")).is_file():
-        raise FileNotFoundError("Config file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise FileNotFoundError(
+            "Config file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
 
     if not Path(os.path.join(sccs_dir, "branches", current_branch, "history")).is_dir():
-        raise FileNotFoundError("History directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise FileNotFoundError(
+            "History directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
 
     if not Path(
         os.path.join(
             sccs_dir, "branches", current_branch, "history", "commit_history.json"
         )
     ).is_file():
-        raise FileNotFoundError("Commit history JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise FileNotFoundError(
+            "Commit history JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+        )
 
     if not Path(docx_path).is_file():
-        raise FileNotFoundError("Docx file not found. Re-initialize SCCS for this file with 'sccs init <file_path>'")
+        raise FileNotFoundError(
+            "Docx file not found. Re-initialize SCCS for this file with 'sccs init <file_path>'"
+        )
+
 
 def wrap_html(html, styles=default_html_styles):
     return (
@@ -149,7 +187,9 @@ def get_current_branch(file_path=current_branch_path):
         ) as current_branch_file:
             current_branch = json.load(current_branch_file).get("current_branch")
             if not current_branch:
-                raise exceptions.InvalidMetadataError("Current branch is missing from JSON. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+                raise exceptions.InvalidMetadataError(
+                    "Current branch is missing from JSON. Please run 'sccs init <file_path>' to initialize SCCS for this file."
+                )
     except Exception as e:
         raise exceptions.FileOpenError(f"Error reading current branch: {e}")
 
@@ -167,6 +207,7 @@ def get_branch_data(file_path=current_branch_path, key=None):
     except Exception as e:
         raise exceptions.FileOpenError(f"Error reading current branch data: {e}")
 
+
 def convert_docx_to_html(docx_path=None):
     if docx_path is None:
         docx_path = current_file_docx_path
@@ -175,4 +216,6 @@ def convert_docx_to_html(docx_path=None):
             result = mammoth.convert_to_html(f)
             return result.value
     except Exception as e:
-        raise exceptions.ConvertingDocumentToHTMLError(f"Error converting .docx to HTML: {e}")
+        raise exceptions.ConvertingDocumentToHTMLError(
+            f"Error converting .docx to HTML: {e}"
+        )

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -41,12 +41,12 @@ def check_sccs_layout(
 
 
     if not Path(os.path.join(sccs_dir, "current_branch")).is_dir():
-        raise exceptions.BranchDoesNotExistError("Current branch directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise exceptions.BranchNotFoundError("Current branch directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     if not Path(
         os.path.join(sccs_dir, "current_branch", "current_branch.json")
     ).is_file():
-        raise exceptions.BranchDoesNotExistError("Current branch file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise exceptions.BranchNotFoundError("Current branch file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     try:
         with open(
@@ -57,13 +57,13 @@ def check_sccs_layout(
         ) as current_branch_file:
             current_branch = json.load(current_branch_file).get("current_branch")
             if not current_branch:
-                raise exceptions.BranchDoesNotExistError("Current branch not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+                raise exceptions.BranchNotFoundError("Current branch not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     except (json.JSONDecodeError, KeyError, TypeError, OSError) as e:
-        raise exceptions.BranchDoesNotExistError("Current branch file is missing or corrupted. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise exceptions.BranchNotFoundError("Current branch file is missing or corrupted. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     if not Path(os.path.join(sccs_dir, "branches", current_branch)).is_dir():
-        raise exceptions.BranchDoesNotExistError("Branch directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
+        raise exceptions.BranchNotFoundError("Branch directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     if not Path(
         os.path.join(sccs_dir, "branches", current_branch, "commit_file_hash")

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -37,27 +37,16 @@ def check_sccs_layout(
 ):
 
     if not Path(sccs_dir).is_dir():
-        print(
-            "This file has not been initialized with SCCS.\nPlease run 'sccs init "
-            "<file_path>' to initialize SCCS for this file."
-        )
-        sys.exit(1)
+        raise exceptions.SCCSNotInitializedError("This file has not been initialized with SCCS.\nPlease run 'sccs init <file_path>' to initialize SCCS for this file.")
+
 
     if not Path(os.path.join(sccs_dir, "current_branch")).is_dir():
-        print(
-            "Current branch directory not found. Please run 'sccs init <file_path>' to "
-            "initialize SCCS for this file."
-        )
-        sys.exit(1)
+        raise exceptions.BranchDoesNotExistError("Current branch directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     if not Path(
         os.path.join(sccs_dir, "current_branch", "current_branch.json")
     ).is_file():
-        print(
-            "Current branch file not found. Please run 'sccs init <file_path>' to "
-            "initialize SCCS for this file."
-        )
-        sys.exit(1)
+        raise exceptions.BranchDoesNotExistError("Current branch file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     try:
         with open(
@@ -68,35 +57,18 @@ def check_sccs_layout(
         ) as current_branch_file:
             current_branch = json.load(current_branch_file).get("current_branch")
             if not current_branch:
-                print(
-                    "Current branch not found. Please run 'sccs init <file_path>' to "
-                    "initialize SCCS for this file."
-                )
-                sys.exit(1)
+                raise exceptions.BranchDoesNotExistError("Current branch not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     except (json.JSONDecodeError, KeyError, TypeError, OSError) as e:
-        print(
-            "Current branch file is missing or corrupted. Please run 'sccs init "
-            "<file_path>' to initialize SCCS for this file."
-        )
-        print("Error: ", e)
-        sys.exit(1)
+        raise exceptions.BranchDoesNotExistError("Current branch file is missing or corrupted. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     if not Path(os.path.join(sccs_dir, "branches", current_branch)).is_dir():
-        print(
-            "Branch directory not found. Please run 'sccs init <file_path>' to "
-            "initialize SCCS for this file."
-        )
-        sys.exit(1)
+        raise exceptions.BranchDoesNotExistError("Branch directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     if not Path(
         os.path.join(sccs_dir, "branches", current_branch, "commit_file_hash")
     ).is_dir():
-        print(
-            "Commit file hash directory not found. Please run 'sccs init <file_path>' "
-            "to initialize SCCS for this file."
-        )
-        sys.exit(1)
+        raise FileNotFoundError("Commit file hash directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     if not Path(
         os.path.join(
             sccs_dir,
@@ -106,95 +78,47 @@ def check_sccs_layout(
             "commit_file_hash.json",
         )
     ).is_file():
-        print(
-            "Commit file hash JSON not found. Please run 'sccs init <file_path>' to "
-            "initialize SCCS for this file."
-        )
-        sys.exit(1)
+        raise FileNotFoundError("Commit file hash JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     if not Path(os.path.join(sccs_dir, "commit_messages")).is_dir():
-        print(
-            "Commit messages directory not found. Please run 'sccs init <file_path>' "
-            "to initialize SCCS for this file."
-        )
-        sys.exit(1)
+        raise FileNotFoundError("Commit messages directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     if not Path(
         os.path.join(sccs_dir, "commit_messages", "commit_messages.json")
     ).is_file():
-        print(
-            "Commit messages JSON not found. Please run 'sccs init <file_path>' to "
-            "initialize SCCS for this file."
-        )
-        sys.exit(1)
+        raise FileNotFoundError("Commit messages JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     if not Path(os.path.join(sccs_dir, "objects")).is_dir():
-        print(
-            "Objects directory not found. Please run 'sccs init <file_path>' to "
-            "initialize SCCS for this file."
-        )
-        sys.exit(1)
+
+        raise FileNotFoundError("Objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     if not Path(os.path.join(sccs_dir, "objects", "docx")).is_dir():
-        print(
-            "Docx objects directory not found. Please run 'sccs init <file_path>' to "
-            "initialize SCCS for this file."
-        )
-        sys.exit(1)
+        raise FileNotFoundError("Docx objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     if not Path(os.path.join(sccs_dir, "objects", "html")).is_dir():
-        print(
-            "HTML objects directory not found. Please run 'sccs init <file_path>' to "
-            "initialize SCCS for this file."
-        )
-        sys.exit(1)
+        raise FileNotFoundError("HTML objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     if not Path(os.path.join(sccs_dir, "objects", "view_html")).is_dir():
-        print(
-            "View HTML objects directory not found. Please run 'sccs init <file_path>' "
-            "to initialize SCCS for this file."
-        )
-        sys.exit(1)
+        raise FileNotFoundError("View HTML objects directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     if not Path(os.path.join(sccs_dir, "config")).is_dir():
-        print(
-            "Config directory not found. Please run 'sccs init <file_path>' to "
-            "initialize SCCS for this file."
-        )
-        sys.exit(1)
+        raise FileNotFoundError("Config directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     if not Path(os.path.join(sccs_dir, "config", "config.json")).is_file():
-        print(
-            "Config file not found. Please run 'sccs init <file_path>' to initialize "
-            "SCCS for this file."
-        )
-        sys.exit(1)
+        raise FileNotFoundError("Config file not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     if not Path(os.path.join(sccs_dir, "branches", current_branch, "history")).is_dir():
-        print(
-            "History directory not found. Please run 'sccs init <file_path>' to "
-            "initialize SCCS for this file."
-        )
-        sys.exit(1)
+        raise FileNotFoundError("History directory not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     if not Path(
         os.path.join(
             sccs_dir, "branches", current_branch, "history", "commit_history.json"
         )
     ).is_file():
-        print(
-            "History file not found. Please run 'sccs init <file_path>' to initialize "
-            "SCCS for this file."
-        )
-        sys.exit(1)
+        raise FileNotFoundError("Commit history JSON not found. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
 
     if not Path(docx_path).is_file():
-        print(
-            "Docx file not found. Re-initialize SCCS for this file with 'sccs init "
-            "<file_path>'"
-        )
-        sys.exit(1)
-
+        raise FileNotFoundError("Docx file not found. Re-initialize SCCS for this file with 'sccs init <file_path>'")
 
 def wrap_html(html, styles=default_html_styles):
     return (
@@ -211,8 +135,7 @@ def hash_current_docx_binary(docx_path=current_file_docx_path):
                 hasher.update(chunk)
             hashed_file = hasher.hexdigest()
     except Exception as e:
-        print(f"Error processing .docx file: {e}")
-        sys.exit(1)
+        raise exceptions.DocumentHashingError(f"Error processing .docx file: {e}")
 
     return hashed_file
 
@@ -224,14 +147,10 @@ def get_current_branch(file_path=current_branch_path):
         ) as current_branch_file:
             current_branch = json.load(current_branch_file).get("current_branch")
             if not current_branch:
-                print(
-                    "Current branch is missing from JSON. Please run 'sccs init "
-                    "<file_path>' to initialize SCCS for this file."
-                )
-                sys.exit(1)
+                raise exceptions.InvalidMetadataError("Current branch is missing from JSON. Please run 'sccs init <file_path>' to initialize SCCS for this file.")
     except Exception as e:
-        print(f"Error reading current branch: {e}")
-        sys.exit(1)
+        raise exceptions.FileOpenError(f"Error reading current branch: {e}")
+
     return current_branch
 
 
@@ -244,9 +163,7 @@ def get_branch_data(file_path=current_branch_path, key=None):
             return data
 
     except Exception as e:
-        print(f"Error reading current branch data: {e}")
-        sys.exit(1)
-
+        raise exceptions.FileOpenError(f"Error reading current branch data: {e}")
 
 def convert_docx_to_html(docx_path=None):
     if docx_path is None:
@@ -256,5 +173,4 @@ def convert_docx_to_html(docx_path=None):
             result = mammoth.convert_to_html(f)
             return result.value
     except Exception as e:
-        print(f"Error converting .docx to HTML: {e}")
-        sys.exit(1)
+        raise exceptions.ConvertingDocumentToHTMLError(f"Error converting .docx to HTML: {e}")

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -210,7 +210,7 @@ def get_current_branch(file_path=current_branch_path):
                     "<file_path>' to initialize SCCS for this file."
                 )
     except Exception as e:
-        raise exceptions.FileOpenError from e 
+        raise exceptions.FileOpenError from e
 
     return current_branch
 

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -17,10 +17,12 @@ current_file_docx_path = os.path.join(
 sccs_versions_directory_path = os.path.join(working_directory_path, ".sccs")
 
 default_html_styles = (
-    """<style>\n* {\nfont-family: Arial, Helvetica, sans-serif;\n}\n\n.inserted 
-    {\nbackground-color: #d4fcbc;\ndisplay: block;\nwidth: fit-content;\n}\n\n.deleted 
-    {\nbackground-color: #fbb6c2;\ndisplay: block;\nwidth: fit-content;\n}\n\n.center 
-    {\ndisplay: flex;\njustify-content: center;\n}\n</style>"""
+    "<style>\n* {\nfont-family: Arial, Helvetica, sans-serif;\n}\n\n"
+    ".inserted {\nbackground-color: #d4fcbc;\ndisplay: block;\nwidth: fit-content;\n}\n"
+    "\n"
+    ".deleted {\nbackground-color: #fbb6c2;\ndisplay: block;\nwidth: fit-content;\n}\n"
+    "\n"
+    ".center {\ndisplay: flex;\njustify-content: center;\n}\n</style>"
 )
 
 current_branch_path = os.path.join(


### PR DESCRIPTION
# Raise Exceptions When Errors Occur #87

This PR focuses on creating a vast exception catalogue in `exceptions.py`, and raise them when errors occur instead of printing an error message and exiting with `sys.exit(1)`.

## Commands/.

- Raise custom exception from `exceptions.py` when an error occurs.

## Exceptions.py

- Create vast list of exceptions to raise when an error occurs.

## Utils.py

- Fix `default_html_styles` to use proper string concatenation.

## Type of Change

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Refactor

`/gemini review`