### PR TITLE
fix: add default SCCS exception messages

### DIFF
--- a/commands/exceptions.py
+++ b/commands/exceptions.py
@@ -5,7 +5,10 @@
 class SCCSException(Exception):
     """Base class for SCCS exceptions."""
 
-    pass
+    default_message = "An SCCS error occurred."
+
+    def __init__(self, message: str | None = None) -> None:
+        super().__init__(self.default_message if message is None else message)
 
 
 # Branch Exceptions
@@ -14,43 +17,43 @@ class SCCSException(Exception):
 class InvalidBranchNameError(SCCSException):
     """Raised when a branch name is invalid."""
 
-    pass
+    default_message = "Branch name is invalid."
 
 
 class BranchMissingFromMetadataError(SCCSException):
     """Raised when a branch is missing from the metadata."""
 
-    pass
+    default_message = "Branch is missing from metadata."
 
 
 class BranchNotFoundError(SCCSException):
     """Raised when a branch is not found."""
 
-    pass
+    default_message = "Branch not found."
 
 
 class ConfigurationError(SCCSException):
     """Raised when there is an error in the SCCS configuration."""
 
-    pass
+    default_message = "SCCS configuration is invalid."
 
 
 class BranchCreationError(SCCSException):
     """Raised when there is an error creating a new branch."""
 
-    pass
+    default_message = "Could not create branch."
 
 
 class BranchDeletionError(SCCSException):
     """Raised when there is an error deleting a branch."""
 
-    pass
+    default_message = "Could not delete branch."
 
 
 class BranchAlreadyExistsError(SCCSException):
     """Raised when a branch already exists."""
 
-    pass
+    default_message = "Branch already exists."
 
 
 # File Operation Exceptions
@@ -59,31 +62,31 @@ class BranchAlreadyExistsError(SCCSException):
 class FileCopyError(SCCSException):
     """Raised when there is an error copying a file."""
 
-    pass
+    default_message = "Could not copy file."
 
 
 class FileWriteError(SCCSException):
     """Raised when there is an error writing to a file."""
 
-    pass
+    default_message = "Could not write file."
 
 
 class FileOpenError(SCCSException):
     """Raised when there is an error opening a file."""
 
-    pass
+    default_message = "Could not open file."
 
 
 class UpdatingMetadataError(SCCSException):
     """Raised when there is an error updating metadata files."""
 
-    pass
+    default_message = "Could not update metadata."
 
 
 class TemporaryFileError(SCCSException):
     """Raised when there is an error creating or replacing a temporary file."""
 
-    pass
+    default_message = "Could not create or replace temporary file."
 
 
 # Invalid Command Call Exceptions
@@ -92,43 +95,43 @@ class TemporaryFileError(SCCSException):
 class InvalidArgumentError(SCCSException):
     """Raised when an invalid argument is provided to a command."""
 
-    pass
+    default_message = "Invalid command argument."
 
 
 class InvalidSubcommandError(SCCSException):
     """Raised when an invalid subcommand is provided to a command."""
 
-    pass
+    default_message = "Invalid subcommand."
 
 
 class UnknownCommandError(SCCSException):
     """Raised when an unknown command is provided."""
 
-    pass
+    default_message = "Unknown command."
 
 
 class InvalidLayoutError(SCCSException):
     """Raised when the SCCS directory layout is invalid or missing."""
 
-    pass
+    default_message = "SCCS directory layout is invalid or incomplete."
 
 
 class SCCSNotInitializedError(SCCSException):
     """Raised when SCCS has not been initialized in the current directory."""
 
-    pass
+    default_message = "SCCS has not been initialized in the current directory."
 
 
 class AlreadyInitializedError(SCCSException):
     """Raised when the document has already been initialized with SCCS."""
 
-    pass
+    default_message = "Document has already been initialized with SCCS."
 
 
 class InvalidFileTypeError(SCCSException):
     """Raised when a file of an invalid type is provided."""
 
-    pass
+    default_message = "Invalid file type."
 
 
 # Not Found Exceptions
@@ -137,13 +140,13 @@ class InvalidFileTypeError(SCCSException):
 class DocumentNotFoundError(SCCSException):
     """Raised when a document is not found."""
 
-    pass
+    default_message = "Document not found."
 
 
 class CommitNotFoundError(SCCSException):
     """Raised when a commit object is not found."""
 
-    pass
+    default_message = "Commit object not found."
 
 
 # Conversion Exceptions
@@ -152,13 +155,13 @@ class CommitNotFoundError(SCCSException):
 class DocumentHashingError(SCCSException):
     """Raised when there is an error hashing a document."""
 
-    pass
+    default_message = "Could not hash document."
 
 
 class ConvertingDocumentToHTMLError(SCCSException):
     """Raised when there is an error converting a document to HTML."""
 
-    pass
+    default_message = "Could not convert document to HTML."
 
 
 # Metadata Exceptions
@@ -167,7 +170,7 @@ class ConvertingDocumentToHTMLError(SCCSException):
 class InvalidMetadataError(SCCSException):
     """Raised when metadata files are corrupted or missing required keys."""
 
-    pass
+    default_message = "Metadata is corrupted or missing required keys."
 
 
 # Uncommitted changes Exceptions
@@ -176,7 +179,7 @@ class InvalidMetadataError(SCCSException):
 class UncommittedChangesError(SCCSException):
     """Raised when there are uncommitted changes that prevent an action."""
 
-    pass
+    default_message = "Uncommitted changes prevent this action."
 
 
 # Input Exceptions
@@ -185,13 +188,13 @@ class UncommittedChangesError(SCCSException):
 class InvalidInputError(SCCSException):
     """Raised when an invalid input is provided."""
 
-    pass
+    default_message = "Invalid input."
 
 
 class EmptyCommitMessageError(SCCSException):
     """Raised when an empty commit message is provided."""
 
-    pass
+    default_message = "Commit message cannot be empty."
 
 
 # Module Exceptions
@@ -201,4 +204,4 @@ class FileImportedAsModuleError(SCCSException):
     """Raised when a script is imported as a module but is intended to be run only as a
     standalone script."""
 
-    pass
+    default_message = "This file cannot be imported as a module."

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Tests for SCCS exception messages."""
+
+import inspect
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "commands"))
+
+import exceptions
+
+
+class SCCSExceptionTests(unittest.TestCase):
+    """Regression coverage for user-facing SCCS exception messages."""
+
+    def test_sccs_exceptions_have_default_messages(self) -> None:
+        """Custom SCCS exceptions should not render as blank messages."""
+
+        for _, exception_cls in inspect.getmembers(exceptions, inspect.isclass):
+            if not issubclass(exception_cls, exceptions.SCCSException):
+                continue
+            with self.subTest(exception_cls=exception_cls.__name__):
+                self.assertTrue(str(exception_cls()))
+
+    def test_explicit_message_is_preserved(self) -> None:
+        """Call-site-specific messages should still override class defaults."""
+
+        self.assertEqual(
+            str(exceptions.FileOpenError("Could not read config.json.")),
+            "Could not read config.json.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# What does this PR do? Fixes #122

Adds default messages for every custom SCCS exception so errors raised without an explicit message no longer render as a blank line. Explicit call-site messages still take precedence.

## commands/exceptions.py

- Adds `SCCSException.default_message` and a base `__init__` that fills in the class default when no message is supplied.
- Gives each custom exception subclass a short user-facing default message.

## tests/test_exceptions.py

- Adds unittest coverage that every SCCS exception renders a non-empty default message.
- Verifies explicit messages are preserved.

## Type of Change

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor

## Validation

- `.venv/bin/python -m unittest discover -s tests`
- `.venv/bin/python commands/sccs init` shows `No file path provided.` instead of a blank custom-error body
- `.venv/bin/python -m py_compile commands/exceptions.py tests/test_exceptions.py`
- `git diff --check`