### PR TITLE
feat: don't format PRs from forks, as checks will always fail

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,8 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
@@ -32,6 +34,9 @@ jobs:
         run: black .
 
       - name: Commit changes
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "style: auto-format with black + isort"
+  
+


### PR DESCRIPTION
# Only Run The Formatting workflow on branch PRs

When someone makes a PR from a fork, it runs the formatting workflow, but the changes cannot be committed to someone else's fork. This will cause the check to always fail on forked PRs. 
