### PR TITLE
Feat/#57 feature sccs revert command

### DIFF
--- a/commands/commit.py
+++ b/commands/commit.py
@@ -15,7 +15,10 @@ import utils
 def get_commit_message() -> str:
     """Retrieve the commit message from the user."""
 
-    return sys.argv[2] if len(sys.argv) > 2 else "No commit message provided."
+    if len(sys.argv) <= 2 or not sys.argv[2].strip():
+        raise exceptions.EmptyCommitMessageError("Commit message cannot be empty.")
+
+    return sys.argv[2].strip()
 
 
 def print_commit_confirmation_message(sha_hash: str) -> None:

--- a/commands/commit.py
+++ b/commands/commit.py
@@ -18,7 +18,7 @@ def get_commit_message() -> str:
     if len(sys.argv) <= 2 or not sys.argv[2].strip():
         raise exceptions.EmptyCommitMessageError("Commit message cannot be empty.")
 
-    return sys.argv[2].strip()
+    return " ".join(sys.argv[2:]).strip()
 
 
 def print_commit_confirmation_message(sha_hash: str) -> None:

--- a/commands/commit.py
+++ b/commands/commit.py
@@ -15,249 +15,7 @@ import utils
 def get_commit_message() -> str:
     """Retrieve the commit message from the user."""
 
-    commit_message = input("Enter commit message: ").strip()
-
-    if commit_message == "":
-        raise exceptions.EmptyCommitMessageError("Commit message cannot be empty.")
-
-    return commit_message
-
-
-def get_timestamp() -> str:
-    """Retrieve the current timestamp."""
-
-    return datetime.now().isoformat()
-
-
-def get_history_path(
-    cwd: Path | None = None, current_branch: str | None = None
-) -> Path:
-    """Retrieve the path to the commit history file."""
-
-    if cwd is None:
-        cwd = utils.working_directory_path
-    if current_branch is None:
-        current_branch = utils.get_current_branch()
-    return (
-        cwd / ".sccs" / "branches" / current_branch / "history" / "commit_history.json"
-    )
-
-
-def get_commit_history() -> dict:
-    """Retrieve the commit history from the commit history file."""
-
-    history_path = get_history_path()
-    if not history_path.is_file():
-        raise FileNotFoundError(
-            "History file not found. Please run 'sccs init <file_path>' to initialize "
-            "SCCS for this file."
-        )
-
-    try:
-        with open(history_path, "r", encoding="utf-8", newline="\n") as history_file:
-            history = json.load(history_file)
-
-    except Exception as e:
-        raise exceptions.FileOpenError from e
-
-    return history
-
-
-def get_parent_hash(history: dict) -> str:
-    """Retrieve the parent hash from the commit history."""
-
-    parent_hash = history["history"].get("latest_commit")
-    return parent_hash
-
-
-def generate_commit_hash(
-    timestamp: str, commit_message: str, name: str, email: str, parent_hash: str
-) -> str:
-    """Generate a SHA-256 hash for the commit."""
-
-    return hashlib.sha256(
-        f"{timestamp}/{commit_message}/{name}/{email}/{parent_hash}".encode()
-    ).hexdigest()
-
-
-def copy_docx_to_objects(
-    sha_hash: str, docx_path: Path | None = None, cwd: Path | None = None
-) -> None:
-    """Copy the current document to the objects directory."""
-
-    if docx_path is None:
-        docx_path = utils.current_file_docx_path
-    if cwd is None:
-        cwd = utils.working_directory_path
-    shutil.copy2(
-        cwd / docx_path.name,
-        cwd / ".sccs" / "objects" / "docx" / f"{sha_hash}.docx",
-    )
-
-
-def write_diff_html(
-    sha_hash: str, docx_html: str, cwd: Path | None = None, styles: str | None = None
-) -> None:
-    """Write the diff HTML file."""
-
-    if cwd is None:
-        cwd = utils.working_directory_path
-    if styles is None:
-        styles = utils.default_html_styles
-    with open(
-        cwd / ".sccs" / "objects" / "html" / f"{sha_hash}.html",
-        "w",
-        encoding="utf-8",
-        newline="\n",
-    ) as f:
-        f.write(styles + docx_html)
-
-
-def write_view_html(sha_hash: str, docx_html: str, cwd: Path | None = None) -> None:
-    """Write the view HTML file."""
-
-    if cwd is None:
-        cwd = utils.working_directory_path
-    with open(
-        cwd / ".sccs" / "objects" / "view_html" / f"{sha_hash}.html",
-        "w",
-        encoding="utf-8",
-        newline="\n",
-    ) as f:
-        f.write(utils.wrap_html(docx_html))
-
-
-def update_commit_log_history(
-    history: dict,
-    sha_hash: str,
-    timestamp: str,
-    name: str,
-    email: str,
-    commit_message: str,
-) -> dict[str, dict]:
-    """Update the commit log history."""
-
-    # Check if history file exists
-    commit_history_path = get_history_path()
-    if not commit_history_path.is_file():
-        raise FileNotFoundError(
-            "History file not found. Please run 'sccs init <file_path>' to initialize "
-            "SCCS for this file."
-        )
-
-    # Update history
-    history["history"]["latest_commit"] = f"{sha_hash}"
-    history["history"]["latest_commit_number"] = (
-        history["history"].get("latest_commit_number", 0) + 1
-    )
-
-    latest_commit_number = history["history"]["latest_commit_number"]
-
-    history["history"]["commit_order"][str(latest_commit_number)] = f"{sha_hash}"
-
-    history["log"][f"{sha_hash}"] = {
-        "timestamp": timestamp,
-        "author": f"{name} <{email}>",
-        "message": commit_message,
-    }
-    return {commit_history_path: history}
-
-
-def update_commit_messages(
-    sha_hash: str, commit_message: str, cwd: Path | None = None
-) -> dict[str, dict]:
-    """Update commit messages."""
-
-    # Check if commit messages file exists
-    if cwd is None:
-        cwd = utils.working_directory_path
-    commit_messages_path = cwd / ".sccs" / "commit_messages" / "commit_messages.json"
-
-    if not commit_messages_path.is_file():
-        raise FileNotFoundError(
-            "Commit messages file not found. Please run 'sccs init <file_path>' to "
-            "initialize SCCS for this file."
-        )
-
-    with open(
-        commit_messages_path, "r", encoding="utf-8", newline="\n"
-    ) as commit_messages_file:
-        try:
-            messages = json.load(commit_messages_file)
-        except Exception as e:
-            raise exceptions.FileOpenError from e
-
-    messages[f"{sha_hash}"] = f"{commit_message}"
-
-    return {commit_messages_path: messages}
-
-
-def update_commit_binary_hash_history(
-    sha_hash: str,
-    hash_docx_binary: str,
-    cwd: Path | None = None,
-    current_branch: str | None = None,
-) -> dict[str, dict]:
-    """Update commit binary hash history."""
-
-    # Update commit file hash
-    if cwd is None:
-        cwd = utils.working_directory_path
-    if current_branch is None:
-        current_branch = utils.get_current_branch()
-
-    commit_file_hash_path = (
-        cwd
-        / ".sccs"
-        / "branches"
-        / current_branch
-        / "commit_file_hash"
-        / "commit_file_hash.json"
-    )
-    if not commit_file_hash_path.is_file():
-        raise FileNotFoundError(
-            "Commit file hash not found. Please run 'sccs init <file_path>' to "
-            f"initialize SCCS for this file."
-        )
-
-    try:
-        with open(commit_file_hash_path, "r", encoding="utf-8", newline="\n") as f:
-            commit_file_hash = json.load(f)
-
-    except Exception as e:
-        raise exceptions.FileOpenError from e
-
-    commit_file_hash[f"{sha_hash}"] = hash_docx_binary
-
-    return {commit_file_hash_path: commit_file_hash}
-
-
-def combine_update_dicts(*dicts: dict[Path, dict]) -> dict[Path, dict]:
-    """Combine multiple update dictionaries into a single dictionary."""
-
-    update_dict = {}
-    for d in dicts:
-        update_dict.update(d)
-    return update_dict
-
-
-def atomically_update_history(update_dict: dict[Path, dict]) -> None:
-    """Atomically update the history files."""
-
-    for key, value in update_dict.items():
-        try:
-            with open(
-                key.with_suffix(".tmp"), "w", encoding="utf-8", newline="\n"
-            ) as f:
-                json.dump(value, f)
-        except Exception as e:
-            raise exceptions.TemporaryFileError from e
-
-    for key, value in update_dict.items():
-        try:
-            key.with_suffix(".tmp").replace(key)
-        except Exception as e:
-            raise exceptions.TemporaryFileError from e
+    return sys.argv[2] if len(sys.argv) > 2 else "No commit message provided."
 
 
 def print_commit_confirmation_message(sha_hash: str) -> None:
@@ -278,39 +36,39 @@ def main() -> None:
 
     commit_message = get_commit_message()
 
-    timestamp = get_timestamp()
+    timestamp = utils.get_timestamp()
 
-    history = get_commit_history()
+    history = utils.get_commit_history()
 
-    parent_hash = get_parent_hash(history)
+    parent_hash = utils.get_parent_hash()
 
-    sha_hash = generate_commit_hash(timestamp, commit_message, name, email, parent_hash)
+    sha_hash = utils.generate_commit_hash(timestamp, commit_message, name, email, parent_hash)
 
-    copy_docx_to_objects(sha_hash)
+    utils.copy_docx_to_objects(sha_hash)
 
-    write_diff_html(sha_hash, docx_html)
+    utils.write_diff_html(sha_hash, docx_html)
 
-    write_view_html(sha_hash, docx_html)
+    utils.write_view_html(sha_hash, docx_html)
 
-    updated_commit_log_history = update_commit_log_history(
+    updated_commit_log_history = utils.update_commit_log_history(
         history, sha_hash, timestamp, name, email, commit_message
     )
 
     current_branch_binary_hash = utils.hash_current_docx_binary()
 
-    updated_commit_binary_hash_history = update_commit_binary_hash_history(
+    updated_commit_binary_hash_history = utils.update_commit_binary_hash_history(
         sha_hash, current_branch_binary_hash
     )
 
-    updated_commit_messages = update_commit_messages(sha_hash, commit_message)
+    updated_commit_messages = utils.update_commit_messages(sha_hash, commit_message)
 
-    combined_history_update_dicts = combine_update_dicts(
+    combined_history_update_dicts = utils.combine_update_dicts(
         updated_commit_log_history,
         updated_commit_binary_hash_history,
         updated_commit_messages,
     )
 
-    atomically_update_history(combined_history_update_dicts)
+    utils.atomically_update_history(combined_history_update_dicts)
 
     print_commit_confirmation_message(sha_hash)
 

--- a/commands/commit.py
+++ b/commands/commit.py
@@ -31,49 +31,7 @@ def main() -> None:
     """Run functions for the <sccs commit> command."""
     utils.check_sccs_layout()
 
-    name = utils.get_key_from_config("name")
-
-    email = utils.get_key_from_config("email")
-
-    docx_html = utils.convert_docx_to_html()
-
-    commit_message = get_commit_message()
-
-    timestamp = utils.get_timestamp()
-
-    history = utils.get_commit_history()
-
-    parent_hash = utils.get_parent_hash(history)
-
-    sha_hash = utils.generate_commit_hash(
-        timestamp, commit_message, name, email, parent_hash
-    )
-
-    utils.copy_docx_to_objects(sha_hash)
-
-    utils.write_diff_html(sha_hash, docx_html)
-
-    utils.write_view_html(sha_hash, docx_html)
-
-    updated_commit_log_history = utils.update_commit_log_history(
-        history, sha_hash, timestamp, name, email, commit_message
-    )
-
-    current_branch_binary_hash = utils.hash_current_docx_binary()
-
-    updated_commit_binary_hash_history = utils.update_commit_binary_hash_history(
-        sha_hash, current_branch_binary_hash
-    )
-
-    updated_commit_messages = utils.update_commit_messages(sha_hash, commit_message)
-
-    combined_history_update_dicts = utils.combine_update_dicts(
-        updated_commit_log_history,
-        updated_commit_binary_hash_history,
-        updated_commit_messages,
-    )
-
-    utils.atomically_update_history(combined_history_update_dicts)
+    sha_hash = utils.commit_changes(get_commit_message())
 
     print_commit_confirmation_message(sha_hash)
 

--- a/commands/commit.py
+++ b/commands/commit.py
@@ -43,7 +43,7 @@ def main() -> None:
 
     history = utils.get_commit_history()
 
-    parent_hash = utils.get_parent_hash()
+    parent_hash = utils.get_parent_hash(history)
 
     sha_hash = utils.generate_commit_hash(
         timestamp, commit_message, name, email, parent_hash

--- a/commands/commit.py
+++ b/commands/commit.py
@@ -42,7 +42,9 @@ def main() -> None:
 
     parent_hash = utils.get_parent_hash()
 
-    sha_hash = utils.generate_commit_hash(timestamp, commit_message, name, email, parent_hash)
+    sha_hash = utils.generate_commit_hash(
+        timestamp, commit_message, name, email, parent_hash
+    )
 
     utils.copy_docx_to_objects(sha_hash)
 

--- a/commands/revert.py
+++ b/commands/revert.py
@@ -45,7 +45,6 @@ def revert(src: Path, dst: Path | None = None) -> None:
     if dst is None:
         dst = utils.current_file_docx_path
 
-
     shutil.copy(src, dst)
 
 

--- a/commands/revert.py
+++ b/commands/revert.py
@@ -1,0 +1,130 @@
+from pathlib import Path
+import sys
+import shutil
+
+import exceptions
+import utils
+
+def get_entered_commit() -> Path | None:
+    """Retrieve the commit file path entered by the user."""
+
+    return Path(sys.argv[2]) if len(sys.argv) > 2 else None
+
+
+def validate_commit(cwd: Path | None = None, commit: Path | None = None) -> Path | None:
+    """Validate the commit file path entered by the user."""
+
+    if cwd is None:
+        cwd = utils.working_directory_path
+
+    if commit is None:
+        raise exceptions.InvalidArgumentError(
+            "No commit file path provided. Please specify a commit file path."
+        )
+    
+    commit = commit.with_suffix(".docx")
+
+    commit = Path(cwd / ".sccs" / "objects" / "docx" / commit)
+
+    if not commit.is_file():
+        raise exceptions.InvalidArgumentError(
+            f"Commit file '{commit}' does not exist. Please provide a valid commit file path."
+        )
+
+    return commit
+
+
+def revert(src: Path, dst: Path | None = None) -> None:
+    """Revert the current document to the specified commit."""
+    
+    if not src.is_file():
+        raise exceptions.InvalidArgumentError(f"Source file '{src}' does not exist.")
+    
+    if dst is None:
+        dst = utils.current_file_docx_path
+
+    if not dst.is_file():
+        raise exceptions.InvalidArgumentError(f"Destination file '{dst}' does not exist.")
+
+    shutil.copy(src, dst)
+    print(f"Document successfully reverted to commit '{src.name}'.")
+
+
+def print_revert_confirmation_message(commit: Path) -> None:
+    """Print a confirmation message for the revert."""
+
+    print(f"Document successfully reverted to commit '{commit.name}'.")
+
+
+def main() -> None:
+    """Main function to handle the revert command."""
+    utils.check_sccs_layout()
+    
+    cwd = utils.working_directory_path
+    commit = get_entered_commit()
+    validated_commit = validate_commit(cwd, commit)
+    revert(validated_commit)
+
+    name = utils.get_key_from_config("name")
+
+    email = utils.get_key_from_config("email")
+
+    docx_html = utils.convert_docx_to_html()
+
+    commit_message = f"Revert to commit '{validated_commit.name}'"
+
+    timestamp = utils.get_timestamp()
+
+    history = utils.get_commit_history()
+
+    parent_hash = utils.get_parent_hash()
+
+    sha_hash = utils.generate_commit_hash(timestamp, commit_message, name, email, parent_hash)
+
+    utils.copy_docx_to_objects(sha_hash)
+
+    utils.write_diff_html(sha_hash, docx_html)
+
+    utils.write_view_html(sha_hash, docx_html)
+
+    updated_commit_log_history = utils.update_commit_log_history(
+        history, sha_hash, timestamp, name, email, commit_message
+    )
+
+    current_branch_binary_hash = utils.hash_current_docx_binary()
+
+    updated_commit_binary_hash_history = utils.update_commit_binary_hash_history(
+        sha_hash, current_branch_binary_hash
+    )
+
+    updated_commit_messages = utils.update_commit_messages(sha_hash, commit_message)
+
+    combined_history_update_dicts = utils.combine_update_dicts(
+        updated_commit_log_history,
+        updated_commit_binary_hash_history,
+        updated_commit_messages,
+    )
+
+    utils.atomically_update_history(combined_history_update_dicts)
+
+if __name__ == "__main__":
+    try:
+        main()
+
+    except exceptions.SCCSException as e:
+        print(f"An error occurred:\n{e}\n")
+        sys.exit(1)
+
+    except Exception as e:
+        print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
+        sys.exit(2)
+else:
+    raise exceptions.FileImportedAsModuleError(
+        "This file cannot be run as a module. Please run it as a script."
+    )
+    
+    
+
+    
+
+    

--- a/commands/revert.py
+++ b/commands/revert.py
@@ -56,7 +56,10 @@ def revert(src: Path, dst: Path | None = None) -> None:
 def print_revert_confirmation_message(commit: Path, new_commit_hash: str) -> None:
     """Print a confirmation message for the revert."""
 
-    print(f"Document successfully reverted to commit '{commit.stem}' on commit '{new_commit_hash}'.")
+    print(
+        f"Document successfully reverted to commit '{commit.stem}' on commit '{new_commit_hash}'."
+    )
+
 
 def main() -> None:
     """Main function to handle the revert command."""

--- a/commands/revert.py
+++ b/commands/revert.py
@@ -29,7 +29,7 @@ def validate_commit(cwd: Path | None = None, commit: Path | None = None) -> Path
 
     if not commit.is_file():
         raise exceptions.InvalidArgumentError(
-            f"Commit file '{commit}' does not exist. Please provide a valid commit file"
+            f"Commit file '{commit.stem}' does not exist. Please provide a valid commit file"
             f" path."
         )
 
@@ -40,7 +40,7 @@ def revert(src: Path, dst: Path | None = None) -> None:
     """Revert the current document to the specified commit."""
 
     if not src.is_file():
-        raise exceptions.InvalidArgumentError(f"Source file '{src}' does not exist.")
+        raise exceptions.InvalidArgumentError(f"Source file '{src.stem}' does not exist.")
 
     if dst is None:
         dst = utils.current_file_docx_path

--- a/commands/revert.py
+++ b/commands/revert.py
@@ -25,7 +25,7 @@ def validate_commit(cwd: Path | None = None, commit: Path | None = None) -> Path
 
     commit = commit.with_suffix(".docx")
 
-    commit = Path(cwd / ".sccs" / "objects" / "docx" / commit)
+    commit = cwd / ".sccs" / "objects" / "docx" / commit.name
 
     if not commit.is_file():
         raise exceptions.InvalidArgumentError(
@@ -75,7 +75,7 @@ def main() -> None:
 
     docx_html = utils.convert_docx_to_html()
 
-    commit_message = f"Revert to commit '{validated_commit.name}'"
+    commit_message = f"Revert to commit '{validated_commit.stem}'"
 
     timestamp = utils.get_timestamp()
 

--- a/commands/revert.py
+++ b/commands/revert.py
@@ -51,14 +51,12 @@ def revert(src: Path, dst: Path | None = None) -> None:
         )
 
     shutil.copy(src, dst)
-    print_revert_confirmation_message(src)
 
 
-def print_revert_confirmation_message(commit: Path) -> None:
+def print_revert_confirmation_message(commit: Path, new_commit_hash: str) -> None:
     """Print a confirmation message for the revert."""
 
-    print(f"Document successfully reverted to commit '{commit.name}'.")
-
+    print(f"Document successfully reverted to commit '{commit.stem}' on commit '{new_commit_hash}'.")
 
 def main() -> None:
     """Main function to handle the revert command."""
@@ -69,49 +67,11 @@ def main() -> None:
     validated_commit = validate_commit(cwd, commit)
     revert(validated_commit)
 
-    name = utils.get_key_from_config("name")
-
-    email = utils.get_key_from_config("email")
-
-    docx_html = utils.convert_docx_to_html()
-
-    commit_message = f"Revert to commit '{validated_commit.stem}'"
-
-    timestamp = utils.get_timestamp()
-
-    history = utils.get_commit_history()
-
-    parent_hash = utils.get_parent_hash(history)
-
-    sha_hash = utils.generate_commit_hash(
-        timestamp, commit_message, name, email, parent_hash
+    new_commit_hash = utils.commit_changes(
+        f"Revert to commit '{validated_commit.stem}'"
     )
 
-    utils.copy_docx_to_objects(sha_hash)
-
-    utils.write_diff_html(sha_hash, docx_html)
-
-    utils.write_view_html(sha_hash, docx_html)
-
-    updated_commit_log_history = utils.update_commit_log_history(
-        history, sha_hash, timestamp, name, email, commit_message
-    )
-
-    current_branch_binary_hash = utils.hash_current_docx_binary()
-
-    updated_commit_binary_hash_history = utils.update_commit_binary_hash_history(
-        sha_hash, current_branch_binary_hash
-    )
-
-    updated_commit_messages = utils.update_commit_messages(sha_hash, commit_message)
-
-    combined_history_update_dicts = utils.combine_update_dicts(
-        updated_commit_log_history,
-        updated_commit_binary_hash_history,
-        updated_commit_messages,
-    )
-
-    utils.atomically_update_history(combined_history_update_dicts)
+    print_revert_confirmation_message(validated_commit, new_commit_hash)
 
 
 if __name__ == "__main__":

--- a/commands/revert.py
+++ b/commands/revert.py
@@ -1,9 +1,10 @@
-from pathlib import Path
-import sys
 import shutil
+import sys
+from pathlib import Path
 
 import exceptions
 import utils
+
 
 def get_entered_commit() -> Path | None:
     """Retrieve the commit file path entered by the user."""
@@ -21,7 +22,7 @@ def validate_commit(cwd: Path | None = None, commit: Path | None = None) -> Path
         raise exceptions.InvalidArgumentError(
             "No commit file path provided. Please specify a commit file path."
         )
-    
+
     commit = commit.with_suffix(".docx")
 
     commit = Path(cwd / ".sccs" / "objects" / "docx" / commit)
@@ -37,10 +38,10 @@ def validate_commit(cwd: Path | None = None, commit: Path | None = None) -> Path
 
 def revert(src: Path, dst: Path | None = None) -> None:
     """Revert the current document to the specified commit."""
-    
+
     if not src.is_file():
         raise exceptions.InvalidArgumentError(f"Source file '{src}' does not exist.")
-    
+
     if dst is None:
         dst = utils.current_file_docx_path
 
@@ -62,7 +63,7 @@ def print_revert_confirmation_message(commit: Path) -> None:
 def main() -> None:
     """Main function to handle the revert command."""
     utils.check_sccs_layout()
-    
+
     cwd = utils.working_directory_path
     commit = get_entered_commit()
     validated_commit = validate_commit(cwd, commit)
@@ -112,6 +113,7 @@ def main() -> None:
 
     utils.atomically_update_history(combined_history_update_dicts)
 
+
 if __name__ == "__main__":
     try:
         main()
@@ -127,9 +129,3 @@ else:
     raise exceptions.FileImportedAsModuleError(
         "This file cannot be run as a module. Please run it as a script."
     )
-    
-    
-
-    
-
-    

--- a/commands/revert.py
+++ b/commands/revert.py
@@ -81,7 +81,7 @@ def main() -> None:
 
     history = utils.get_commit_history()
 
-    parent_hash = utils.get_parent_hash()
+    parent_hash = utils.get_parent_hash(history)
 
     sha_hash = utils.generate_commit_hash(
         timestamp, commit_message, name, email, parent_hash

--- a/commands/revert.py
+++ b/commands/revert.py
@@ -45,10 +45,6 @@ def revert(src: Path, dst: Path | None = None) -> None:
     if dst is None:
         dst = utils.current_file_docx_path
 
-    if not dst.is_file():
-        raise exceptions.InvalidArgumentError(
-            f"Destination file '{dst}' does not exist."
-        )
 
     shutil.copy(src, dst)
 

--- a/commands/revert.py
+++ b/commands/revert.py
@@ -12,7 +12,7 @@ def get_entered_commit() -> Path | None:
     return Path(sys.argv[2]) if len(sys.argv) > 2 else None
 
 
-def validate_commit(cwd: Path | None = None, commit: Path | None = None) -> Path | None:
+def validate_commit(cwd: Path | None = None, commit: Path | None = None) -> Path:
     """Validate the commit file path entered by the user."""
 
     if cwd is None:

--- a/commands/revert.py
+++ b/commands/revert.py
@@ -28,7 +28,8 @@ def validate_commit(cwd: Path | None = None, commit: Path | None = None) -> Path
 
     if not commit.is_file():
         raise exceptions.InvalidArgumentError(
-            f"Commit file '{commit}' does not exist. Please provide a valid commit file path."
+            f"Commit file '{commit}' does not exist. Please provide a valid commit file"
+            f" path."
         )
 
     return commit
@@ -44,10 +45,12 @@ def revert(src: Path, dst: Path | None = None) -> None:
         dst = utils.current_file_docx_path
 
     if not dst.is_file():
-        raise exceptions.InvalidArgumentError(f"Destination file '{dst}' does not exist.")
+        raise exceptions.InvalidArgumentError(
+            f"Destination file '{dst}' does not exist."
+        )
 
     shutil.copy(src, dst)
-    print(f"Document successfully reverted to commit '{src.name}'.")
+    print_revert_confirmation_message(src)
 
 
 def print_revert_confirmation_message(commit: Path) -> None:
@@ -79,7 +82,9 @@ def main() -> None:
 
     parent_hash = utils.get_parent_hash()
 
-    sha_hash = utils.generate_commit_hash(timestamp, commit_message, name, email, parent_hash)
+    sha_hash = utils.generate_commit_hash(
+        timestamp, commit_message, name, email, parent_hash
+    )
 
     utils.copy_docx_to_objects(sha_hash)
 

--- a/commands/revert.py
+++ b/commands/revert.py
@@ -40,7 +40,9 @@ def revert(src: Path, dst: Path | None = None) -> None:
     """Revert the current document to the specified commit."""
 
     if not src.is_file():
-        raise exceptions.InvalidArgumentError(f"Source file '{src.stem}' does not exist.")
+        raise exceptions.InvalidArgumentError(
+            f"Source file '{src.stem}' does not exist."
+        )
 
     if dst is None:
         dst = utils.current_file_docx_path

--- a/commands/revert.py
+++ b/commands/revert.py
@@ -47,7 +47,7 @@ def revert(src: Path, dst: Path | None = None) -> None:
     if dst is None:
         dst = utils.current_file_docx_path
 
-    shutil.copy(src, dst)
+    shutil.copy2(src, dst)
 
 
 def print_revert_confirmation_message(commit: Path, new_commit_hash: str) -> None:

--- a/commands/sccs
+++ b/commands/sccs
@@ -19,7 +19,8 @@ COMMANDS = [
     "switch",
     "publish",
     "clone",
-    "config"
+    "config",
+    "revert"
 ]
 
 

--- a/commands/sccs.bat
+++ b/commands/sccs.bat
@@ -75,6 +75,12 @@ if "%command%"=="config" (
     exit /b !errorlevel!
 )
 
+if "%command%"=="revert" (
+    set "script_directory=%~dp0"
+    python "%script_directory%revert.py" %*
+    exit /b !errorlevel!
+)
+
 echo Unknown command: %command%
 echo Invalid command. Please use "init", "commit", "open", "log", "status", "diff", "help", "branch", "switch", "publish", "clone", or "config", along with required arguments
 echo For help, use the 'sccs help' command

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -532,7 +532,7 @@ def commit_changes(commit_msg: str) -> str:
 
     history = get_commit_history()
 
-    parent_hash = get_parent_hash()
+    parent_hash = get_parent_hash(history)
 
     sha_hash = generate_commit_hash(timestamp, commit_message, name, email, parent_hash)
 

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -328,7 +328,7 @@ def get_parent_hash(history: dict | None = None) -> str | None:
 
 
 def generate_commit_hash(
-    timestamp: str, commit_message: str, name: str, email: str, parent_hash: str
+    timestamp: str, commit_message: str, name: str, email: str, parent_hash: str | None
 ) -> str:
     """Generate a SHA-256 hash for the commit."""
 

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -7,6 +7,9 @@ import re
 import shutil
 from datetime import datetime
 from pathlib import Path
+import shutil
+
+from requests import utils
 
 import exceptions
 import mammoth
@@ -515,3 +518,53 @@ def atomically_update_history(update_dict: dict[Path, dict]) -> None:
             key.with_suffix(".tmp").replace(key)
         except Exception as e:
             raise exceptions.TemporaryFileError from e
+
+
+def commit_changes(commit_msg: str) -> str:
+    """Commit changes to the current branch with the given commit information."""
+
+    name = get_key_from_config("name")
+
+    email = get_key_from_config("email")
+
+    docx_html = convert_docx_to_html()
+
+    commit_message = commit_msg
+
+    timestamp = get_timestamp()
+
+    history = get_commit_history()
+
+    parent_hash = get_parent_hash()
+
+    sha_hash =generate_commit_hash(
+        timestamp, commit_message, name, email, parent_hash
+    )
+
+    copy_docx_to_objects(sha_hash)
+
+    write_diff_html(sha_hash, docx_html)
+
+    write_view_html(sha_hash, docx_html)
+
+    updated_commit_log_history = update_commit_log_history(
+        history, sha_hash, timestamp, name, email, commit_message
+    )
+
+    current_branch_binary_hash = hash_current_docx_binary()
+
+    updated_commit_binary_hash_history = update_commit_binary_hash_history(
+        sha_hash, current_branch_binary_hash
+    )
+
+    updated_commit_messages = update_commit_messages(sha_hash, commit_message)
+
+    combined_history_update_dicts = combine_update_dicts(
+        updated_commit_log_history,
+        updated_commit_binary_hash_history,
+        updated_commit_messages,
+    )
+
+    atomically_update_history(combined_history_update_dicts)
+
+    return sha_hash

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 """Module for utility functions used in SCCS."""
 
+from datetime import datetime
 import hashlib
 import json
 import re
 from pathlib import Path
+import shutil
 
 import exceptions
 import mammoth
@@ -275,3 +277,243 @@ def write_key_to_config(key: str, value: str, cwd: Path | None = None) -> None:
         f.seek(0)
         json.dump(config, f, indent=4)
         f.truncate()
+
+
+def get_timestamp() -> str:
+    """Retrieve the current timestamp."""
+
+    return datetime.now().isoformat()
+
+
+def get_history_path(
+    cwd: Path | None = None, current_branch: str | None = None
+) -> Path:
+    """Retrieve the path to the commit history file."""
+
+    if cwd is None:
+        cwd = working_directory_path
+    if current_branch is None:
+        current_branch = get_current_branch()
+    return (
+        cwd / ".sccs" / "branches" / current_branch / "history" / "commit_history.json"
+    )
+
+
+def get_commit_history() -> dict:
+    """Retrieve the commit history from the commit history file."""
+
+    history_path = get_history_path()
+    if not history_path.is_file():
+        raise FileNotFoundError(
+            "History file not found. Please run 'sccs init <file_path>' to initialize "
+            "SCCS for this file."
+        )
+
+    try:
+        with open(history_path, "r", encoding="utf-8", newline="\n") as history_file:
+            history = json.load(history_file)
+
+    except Exception as e:
+        raise exceptions.FileOpenError from e
+
+    return history
+
+
+def get_parent_hash(history: dict | None = None) -> str:
+    """Retrieve the parent hash from the commit history."""
+    if history is None:
+        history = get_commit_history()
+    parent_hash = history["history"].get("latest_commit")
+    return parent_hash
+
+
+def generate_commit_hash(
+    timestamp: str, commit_message: str, name: str, email: str, parent_hash: str
+) -> str:
+    """Generate a SHA-256 hash for the commit."""
+
+    return hashlib.sha256(
+        f"{timestamp}/{commit_message}/{name}/{email}/{parent_hash}".encode()
+    ).hexdigest()
+
+
+def copy_docx_to_objects(
+    sha_hash: str, docx_path: Path | None = None, cwd: Path | None = None
+) -> None:
+    """Copy the current document to the objects directory."""
+
+    if docx_path is None:
+        docx_path = current_file_docx_path
+    if cwd is None:
+        cwd = working_directory_path
+    shutil.copy2(
+        cwd / docx_path.name,
+        cwd / ".sccs" / "objects" / "docx" / f"{sha_hash}.docx",
+    )
+
+
+def write_diff_html(
+    sha_hash: str, docx_html: str, cwd: Path | None = None, styles: str | None = None
+) -> None:
+    """Write the diff HTML file."""
+
+    if cwd is None:
+        cwd = working_directory_path
+    if styles is None:
+        styles = default_html_styles
+    with open(
+        cwd / ".sccs" / "objects" / "html" / f"{sha_hash}.html",
+        "w",
+        encoding="utf-8",
+        newline="\n",
+    ) as f:
+        f.write(styles + docx_html)
+
+
+def write_view_html(sha_hash: str, docx_html: str, cwd: Path | None = None) -> None:
+    """Write the view HTML file."""
+
+    if cwd is None:
+        cwd = working_directory_path
+    with open(
+        cwd / ".sccs" / "objects" / "view_html" / f"{sha_hash}.html",
+        "w",
+        encoding="utf-8",
+        newline="\n",
+    ) as f:
+        f.write(wrap_html(docx_html))
+
+
+def update_commit_binary_hash_history(
+    sha_hash: str,
+    hash_docx_binary: str,
+    cwd: Path | None = None,
+    current_branch: str | None = None,
+) -> dict[str, dict]:
+    """Update commit binary hash history."""
+
+    # Update commit file hash
+    if cwd is None:
+        cwd = working_directory_path
+    if current_branch is None:
+        current_branch = get_current_branch()
+
+    commit_file_hash_path = (
+        cwd
+        / ".sccs"
+        / "branches"
+        / current_branch
+        / "commit_file_hash"
+        / "commit_file_hash.json"
+    )
+    if not commit_file_hash_path.is_file():
+        raise FileNotFoundError(
+            "Commit file hash not found. Please run 'sccs init <file_path>' to "
+            f"initialize SCCS for this file."
+        )
+
+    try:
+        with open(commit_file_hash_path, "r", encoding="utf-8", newline="\n") as f:
+            commit_file_hash = json.load(f)
+
+    except Exception as e:
+        raise exceptions.FileOpenError from e
+
+    commit_file_hash[f"{sha_hash}"] = hash_docx_binary
+
+    return {commit_file_hash_path: commit_file_hash}
+
+
+def update_commit_messages(
+    sha_hash: str, commit_message: str, cwd: Path | None = None
+) -> dict[str, dict]:
+    """Update commit messages."""
+
+    # Check if commit messages file exists
+    if cwd is None:
+        cwd = working_directory_path
+    commit_messages_path = cwd / ".sccs" / "commit_messages" / "commit_messages.json"
+
+    if not commit_messages_path.is_file():
+        raise FileNotFoundError(
+            "Commit messages file not found. Please run 'sccs init <file_path>' to "
+            "initialize SCCS for this file."
+        )
+
+    with open(
+        commit_messages_path, "r", encoding="utf-8", newline="\n"
+    ) as commit_messages_file:
+        try:
+            messages = json.load(commit_messages_file)
+        except Exception as e:
+            raise exceptions.FileOpenError from e
+
+    messages[f"{sha_hash}"] = f"{commit_message}"
+
+    return {commit_messages_path: messages}
+
+
+def update_commit_log_history(
+    history: dict,
+    sha_hash: str,
+    timestamp: str,
+    name: str,
+    email: str,
+    commit_message: str,
+) -> dict[str, dict]:
+    """Update the commit log history."""
+
+    # Check if history file exists
+    commit_history_path = get_history_path()
+    if not commit_history_path.is_file():
+        raise FileNotFoundError(
+            "History file not found. Please run 'sccs init <file_path>' to initialize "
+            "SCCS for this file."
+        )
+
+    # Update history
+    history["history"]["latest_commit"] = f"{sha_hash}"
+    history["history"]["latest_commit_number"] = (
+        history["history"].get("latest_commit_number", 0) + 1
+    )
+
+    latest_commit_number = history["history"]["latest_commit_number"]
+
+    history["history"]["commit_order"][str(latest_commit_number)] = f"{sha_hash}"
+
+    history["log"][f"{sha_hash}"] = {
+        "timestamp": timestamp,
+        "author": f"{name} <{email}>",
+        "message": commit_message,
+    }
+    return {commit_history_path: history}
+
+
+def combine_update_dicts(*dicts: dict[Path, dict]) -> dict[Path, dict]:
+    """Combine multiple update dictionaries into a single dictionary."""
+
+    update_dict = {}
+    for d in dicts:
+        update_dict.update(d)
+    return update_dict
+
+
+def atomically_update_history(update_dict: dict[Path, dict]) -> None:
+    """Atomically update the history files."""
+
+    for key, value in update_dict.items():
+        try:
+            with open(
+                key.with_suffix(".tmp"), "w", encoding="utf-8", newline="\n"
+            ) as f:
+                json.dump(value, f)
+        except Exception as e:
+            raise exceptions.TemporaryFileError from e
+
+    for key, value in update_dict.items():
+        try:
+            key.with_suffix(".tmp").replace(key)
+        except Exception as e:
+            raise exceptions.TemporaryFileError from e
+
+

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """Module for utility functions used in SCCS."""
 
-from datetime import datetime
 import hashlib
 import json
 import re
-from pathlib import Path
 import shutil
+from datetime import datetime
+from pathlib import Path
 
 import exceptions
 import mammoth
@@ -515,5 +515,3 @@ def atomically_update_history(update_dict: dict[Path, dict]) -> None:
             key.with_suffix(".tmp").replace(key)
         except Exception as e:
             raise exceptions.TemporaryFileError from e
-
-

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -7,12 +7,10 @@ import re
 import shutil
 from datetime import datetime
 from pathlib import Path
-import shutil
-
-from requests import utils
 
 import exceptions
 import mammoth
+from requests import utils
 
 working_directory_path = Path.cwd()
 
@@ -537,9 +535,7 @@ def commit_changes(commit_msg: str) -> str:
 
     parent_hash = get_parent_hash()
 
-    sha_hash =generate_commit_hash(
-        timestamp, commit_message, name, email, parent_hash
-    )
+    sha_hash = generate_commit_hash(timestamp, commit_message, name, email, parent_hash)
 
     copy_docx_to_objects(sha_hash)
 

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -319,7 +319,7 @@ def get_commit_history() -> dict:
     return history
 
 
-def get_parent_hash(history: dict | None = None) -> str:
+def get_parent_hash(history: dict | None = None) -> str | None:
     """Retrieve the parent hash from the commit history."""
     if history is None:
         history = get_commit_history()

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 import exceptions
 import mammoth
-from requests import utils
 
 working_directory_path = Path.cwd()
 


### PR DESCRIPTION
# Create SCCS Revert Command (#57)

This PR focuses on creating a new command `sccs revert` which reverts to a previous commit.

## SCCS (sh/py), SCCS.bat

- Create tunnels for `sccs revert <commit>

## Commit..py

- Move most commit functions to `utils.py`
- Get commit message as argument

## Utils.py

- Add many functions from `commit.py`

## Revert.py

- Get the entered commit to revert to.
- Overwrite that commit as the repository document.
- Commit the updated changes, creating a 'revert commit'

## Type of Change

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
