### PR TITLE
Allow command modules to be imported

### DIFF
--- a/commands/branch.py
+++ b/commands/branch.py
@@ -237,7 +237,3 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
         sys.exit(2)
-else:
-    raise exceptions.FileImportedAsModuleError(
-        "This file cannot be run as a module. Please run it as a script."
-    )

--- a/commands/clone.py
+++ b/commands/clone.py
@@ -13,13 +13,15 @@ def get_entered_url() -> str | None:
     """Retrieve the URL entered by the user."""
     return sys.argv[2] if len(sys.argv) > 2 else None
 
-
-def resolve_entered_url(url: str = get_entered_url()) -> str:
+def resolve_entered_url(url: str | None = None) -> str:
     """
     Resolve the entered URL by adding 'https://' if missing and appending '/clone'
     if missing."""
 
     if url is None:
+        url = get_entered_url()
+
+    if url == "":
         print("No URL entered.")
         raise exceptions.InvalidArgumentError("No URL entered.")
 
@@ -35,8 +37,12 @@ def resolve_entered_url(url: str = get_entered_url()) -> str:
     return url
 
 
-def request_repo(url: str = resolve_entered_url()) -> requests.Response:
+def request_repo(url: str | None = None) -> requests.Response:
     """Request the repository from the given URL."""
+
+    if url is None:
+        url = resolve_entered_url()
+
     try:
         response = requests.get(url)
     except Exception as e:
@@ -92,7 +98,3 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
         sys.exit(2)
-else:
-    raise exceptions.FileImportedAsModuleError(
-        "This file cannot be run as a module. Please run it as a script."
-    )

--- a/commands/commit.py
+++ b/commands/commit.py
@@ -47,7 +47,3 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
         sys.exit(2)
-else:
-    raise exceptions.FileImportedAsModuleError(
-        "This file cannot be run as a module. Please run it as a script."
-    )

--- a/commands/config.py
+++ b/commands/config.py
@@ -88,7 +88,3 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
         sys.exit(2)
-else:
-    raise exceptions.FileImportedAsModuleError(
-        "This file cannot be run as a module. Please run it as a script."
-    )

--- a/commands/diff.py
+++ b/commands/diff.py
@@ -279,7 +279,3 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
         sys.exit(2)
-else:
-    raise exceptions.FileImportedAsModuleError(
-        "This file cannot be run as a module. Please run it as a script."
-    )

--- a/commands/help.py
+++ b/commands/help.py
@@ -45,7 +45,3 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
         sys.exit(2)
-else:
-    raise exceptions.FileImportedAsModuleError(
-        "This file cannot be run as a module. Please run it as a script."
-    )

--- a/commands/init.py
+++ b/commands/init.py
@@ -342,7 +342,3 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
         sys.exit(2)
-else:
-    raise exceptions.FileImportedAsModuleError(
-        "This file cannot be run as a module. Please run it as a script."
-    )

--- a/commands/log.py
+++ b/commands/log.py
@@ -67,7 +67,3 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
         sys.exit(2)
-else:
-    raise exceptions.FileImportedAsModuleError(
-        "This file cannot be run as a module. Please run it as a script."
-    )

--- a/commands/open.py
+++ b/commands/open.py
@@ -111,7 +111,3 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
         sys.exit(2)
-else:
-    raise exceptions.FileImportedAsModuleError(
-        "This file cannot be run as a module. Please run it as a script."
-    )

--- a/commands/publish.py
+++ b/commands/publish.py
@@ -107,7 +107,3 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
         sys.exit(2)
-else:
-    raise exceptions.FileImportedAsModuleError(
-        "This file cannot be run as a module. Please run it as a script."
-    )

--- a/commands/revert.py
+++ b/commands/revert.py
@@ -85,7 +85,3 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
         sys.exit(2)
-else:
-    raise exceptions.FileImportedAsModuleError(
-        "This file cannot be run as a module. Please run it as a script."
-    )

--- a/commands/sccs
+++ b/commands/sccs
@@ -72,10 +72,6 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
         sys.exit(2)
-else:
-    raise exceptions.FileImportedAsModuleError(
-        "This file cannot be run as a module. Please run it as a script."
-    )
 
 # If on MacOS / Linux, move this file, commit.py, init.py, open.py, log.py, diff.py,
 # status.py, help.py, branch.py , and switch.py to /usr/local/bin and make it executable

--- a/commands/status.py
+++ b/commands/status.py
@@ -131,7 +131,3 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
         sys.exit(2)
-else:
-    raise exceptions.FileImportedAsModuleError(
-        "This file cannot be run as a module. Please run it as a script."
-    )

--- a/commands/switch.py
+++ b/commands/switch.py
@@ -184,7 +184,3 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
         sys.exit(2)
-else:
-    raise exceptions.FileImportedAsModuleError(
-        "This file cannot be run as a module. Please run it as a script."
-    )


### PR DESCRIPTION
## Summary

Closes #137

Allows SCCS command modules to be imported without raising import-time errors.

The `if __name__ == "__main__"` guards are preserved, so command behavior when run as scripts is unchanged.

Also removes import-time URL resolution in `clone.py`, so importing the module no longer evaluates CLI arguments immediately.

## Testing

- Confirmed all Python files in `commands/` can be imported successfully.
- Confirmed extensionless `commands/sccs` can be loaded successfully.
- Ran `python -m pytest` after installing `pytest` locally because it is not listed in `requirements.txt`.
- Result: `2 passed`.

## Type of Change

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor