### PR TITLE
fix: Ensure all file check SCCS layout

### DIFF
--- a/commands/clone.py
+++ b/commands/clone.py
@@ -68,6 +68,8 @@ def unzip_repo_file(buffer: io.BytesIO, destination: str) -> None:
 
 def main() -> None:
     """Run functions for the <sccs clone> command."""
+    import utils
+    utils.check_sccs_layout()
     response = request_repo()
 
     repo_name = resolve_entered_url().split("/")[-2]

--- a/commands/config.py
+++ b/commands/config.py
@@ -66,6 +66,7 @@ def resolve_entered_remote(remote: str) -> str:
 
 def main() -> None:
     """Run functions for the <sccs config> command."""
+    utils.check_sccs_layout()
     key = get_entered_config_key()
     value = get_entered_config_value()
 

--- a/commands/publish.py
+++ b/commands/publish.py
@@ -81,6 +81,7 @@ def post_repo(buffer: io.BytesIO, remote: str) -> requests.Response:
 
 def main() -> None:
     """Run functions for the <sccs publish> command."""
+    utils.check_sccs_layout()
     reset_current_branch()
 
     remote = utils.get_key_from_config("remote")


### PR DESCRIPTION
Closes #136. Added calls to utils.check_sccs_layout() in publish.py, config.py (handling origin setup), and clone.py to verify repository layout before command execution.