### PR TITLE
Feat/#135 feature use start of hash for args

### DIFF
--- a/commands/clone.py
+++ b/commands/clone.py
@@ -13,6 +13,7 @@ def get_entered_url() -> str | None:
     """Retrieve the URL entered by the user."""
     return sys.argv[2] if len(sys.argv) > 2 else None
 
+
 def resolve_entered_url(url: str | None = None) -> str:
     """
     Resolve the entered URL by adding 'https://' if missing and appending '/clone'

--- a/commands/diff.py
+++ b/commands/diff.py
@@ -224,7 +224,11 @@ def main() -> None:
 
     docx_current_version_html = utils.convert_docx_to_html()
 
-    commit_html = get_commit_html(utils.validate_commit("html", utils.working_directory_path, get_entered_commit_to_diff()))
+    commit_html = get_commit_html(
+        utils.validate_commit(
+            "html", utils.working_directory_path, get_entered_commit_to_diff()
+        )
+    )
 
     bs4_docx_current_version_soup = convert_html_to_soup(docx_current_version_html)
 

--- a/commands/diff.py
+++ b/commands/diff.py
@@ -17,28 +17,6 @@ def get_entered_commit_to_diff() -> Path | None:
     return Path(sys.argv[2]) if len(sys.argv) > 2 else None
 
 
-def validate_commit(commit_to_diff: Path, docx_current_version: Path) -> None:
-    """Validate the commit file and current docx file paths."""
-
-    if not commit_to_diff:
-        raise exceptions.InvalidArgumentError("No commit file path provided.")
-
-    if not commit_to_diff.is_file():
-        raise FileNotFoundError(
-            "Commit file not found. Please provide a valid commit file path."
-        )
-
-    if commit_to_diff.suffix.lower() != ".html":
-        raise exceptions.InvalidArgumentError(
-            "Commit file is not a .html file. Please provide a valid .html commit file"
-        )
-
-    if not docx_current_version.is_file():
-        raise FileNotFoundError(
-            "Docx file not found. Please provide a valid docx file path."
-        )
-
-
 def get_commit_html(commit_path: Path) -> str:
     """Read and return the HTML content of a commit file."""
 
@@ -244,11 +222,9 @@ def main() -> None:
     """Run functions for the <sccs diff> command."""
     utils.check_sccs_layout()
 
-    validate_commit(get_entered_commit_to_diff(), utils.current_file_docx_path)
-
     docx_current_version_html = utils.convert_docx_to_html()
 
-    commit_html = get_commit_html(get_entered_commit_to_diff())
+    commit_html = get_commit_html(utils.validate_commit("html", utils.working_directory_path, get_entered_commit_to_diff()))
 
     bs4_docx_current_version_soup = convert_html_to_soup(docx_current_version_html)
 

--- a/commands/log.py
+++ b/commands/log.py
@@ -40,7 +40,7 @@ def print_log() -> None:
     for entry in log_data["log"]:
         print(
             "------------------------------\n"
-            f"Commit File: {entry}\n"
+            f"Commit File: {entry[:10]}\n"
             f"Author: {log_data['log'][entry]['author']}\n"
             f"Date: {log_data['log'][entry]['timestamp']}\n"
             f"Message: {log_data['log'][entry]['message']}\n"

--- a/commands/open.py
+++ b/commands/open.py
@@ -11,19 +11,7 @@ import utils
 
 def get_commit_path_input() -> Path | None:
     """Get the absolute path of the commit file from the command-line arguments."""
-    return Path(sys.argv[2]).resolve() if len(sys.argv) > 2 else None
-
-
-def check_commit_path_input(commit_path: Path) -> None:
-    """Check the validity of the commit file path."""
-    if not commit_path:
-        raise exceptions.InvalidArgumentError("Commit file path cannot be empty.")
-
-    if not commit_path.is_file():
-        raise FileNotFoundError("Commit file does not exist.")
-
-    if commit_path.suffix.lower() != ".docx":
-        raise exceptions.InvalidFileTypeError("Commit file is not a .docx file.")
+    return Path(sys.argv[2]) if len(sys.argv) > 2 else None
 
 
 def confirm_before_proceeding(
@@ -87,9 +75,7 @@ def main() -> None:
 
     utils.check_sccs_layout()
 
-    commit_path = get_commit_path_input()
-
-    check_commit_path_input(commit_path)
+    commit_path = utils.validate_commit("docx", utils.working_directory_path, get_commit_path_input())
 
     check_changes(commit_path)
 

--- a/commands/open.py
+++ b/commands/open.py
@@ -75,7 +75,9 @@ def main() -> None:
 
     utils.check_sccs_layout()
 
-    commit_path = utils.validate_commit("docx", utils.working_directory_path, get_commit_path_input())
+    commit_path = utils.validate_commit(
+        "docx", utils.working_directory_path, get_commit_path_input()
+    )
 
     check_changes(commit_path)
 

--- a/commands/revert.py
+++ b/commands/revert.py
@@ -12,30 +12,6 @@ def get_entered_commit() -> Path | None:
     return Path(sys.argv[2]) if len(sys.argv) > 2 else None
 
 
-def validate_commit(cwd: Path | None = None, commit: Path | None = None) -> Path:
-    """Validate the commit file path entered by the user."""
-
-    if cwd is None:
-        cwd = utils.working_directory_path
-
-    if commit is None:
-        raise exceptions.InvalidArgumentError(
-            "No commit file path provided. Please specify a commit file path."
-        )
-
-    commit = commit.with_suffix(".docx")
-
-    commit = cwd / ".sccs" / "objects" / "docx" / commit.name
-
-    if not commit.is_file():
-        raise exceptions.InvalidArgumentError(
-            f"Commit file '{commit.stem}' does not exist. Please provide a valid commit file"
-            f" path."
-        )
-
-    return commit
-
-
 def revert(src: Path, dst: Path | None = None) -> None:
     """Revert the current document to the specified commit."""
 
@@ -64,7 +40,7 @@ def main() -> None:
 
     cwd = utils.working_directory_path
     commit = get_entered_commit()
-    validated_commit = validate_commit(cwd, commit)
+    validated_commit = utils.validate_commit("docx", cwd, commit)
     revert(validated_commit)
 
     new_commit_hash = utils.commit_changes(

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -565,7 +565,11 @@ def commit_changes(commit_msg: str) -> str:
     return sha_hash
 
 
-def validate_commit(folder: str, cwd: Path | None = None, commit: Path | None = None, ) -> Path:
+def validate_commit(
+    folder: str,
+    cwd: Path | None = None,
+    commit: Path | None = None,
+) -> Path:
     """Validate the commit file path entered by the user."""
 
     if cwd is None:
@@ -575,7 +579,7 @@ def validate_commit(folder: str, cwd: Path | None = None, commit: Path | None = 
         raise exceptions.InvalidArgumentError(
             "No commit file path provided. Please specify a commit file path."
         )
-    
+
     if len(commit.stem.strip()) != 64 and len(commit.stem.strip()) != 10:
         raise exceptions.InvalidArgumentError(
             "Invalid commit file name. Please provide a shortened, 10 character commit hash or the full 64 character commit hash as the commit identifier."
@@ -588,9 +592,9 @@ def validate_commit(folder: str, cwd: Path | None = None, commit: Path | None = 
             commit = file
 
     if not commit.is_file():
-         raise exceptions.InvalidArgumentError(
+        raise exceptions.InvalidArgumentError(
             f"Commit file '{commit}' does not exist. Please provide a valid commit file"
             f" path."
         )
-    
+
     return commit

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -572,6 +572,8 @@ def validate_commit(
 ) -> Path:
     """Validate the commit file path entered by the user."""
 
+    commit = Path(commit.strip()) if commit else None
+
     if cwd is None:
         cwd = working_directory_path
 
@@ -587,14 +589,22 @@ def validate_commit(
 
     objects_dir = cwd / ".sccs" / "objects" / folder
 
-    for file in objects_dir.iterdir():
-        if str(file.stem).startswith(str(commit)):
-            commit = file
+    matching_files = []
 
-    if not commit.is_file():
-        raise exceptions.InvalidArgumentError(
+    for file in objects_dir.iterdir():
+
+        if str(file.stem).startswith(str(commit.stem.strip())):
+            matching_files.append(file)
+
+    if not matching_files:
+         raise exceptions.InvalidArgumentError(
             f"Commit file '{commit}' does not exist. Please provide a valid commit file"
             f" path."
         )
+    
+    if len(matching_files) > 1:
+        raise exceptions.InvalidArgumentError(
+            f"Multiple commit files found matching '{commit}'. Please provide a full, 64 character commit hash."
+        )
 
-    return commit
+    return matching_files[0]

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -597,11 +597,11 @@ def validate_commit(
             matching_files.append(file)
 
     if not matching_files:
-         raise exceptions.InvalidArgumentError(
+        raise exceptions.InvalidArgumentError(
             f"Commit file '{commit}' does not exist. Please provide a valid commit file"
             f" path."
         )
-    
+
     if len(matching_files) > 1:
         raise exceptions.InvalidArgumentError(
             f"Multiple commit files found matching '{commit}'. Please provide a full, 64 character commit hash."

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -563,3 +563,34 @@ def commit_changes(commit_msg: str) -> str:
     atomically_update_history(combined_history_update_dicts)
 
     return sha_hash
+
+
+def validate_commit(folder: str, cwd: Path | None = None, commit: Path | None = None, ) -> Path:
+    """Validate the commit file path entered by the user."""
+
+    if cwd is None:
+        cwd = working_directory_path
+
+    if commit is None:
+        raise exceptions.InvalidArgumentError(
+            "No commit file path provided. Please specify a commit file path."
+        )
+    
+    if len(commit.stem.strip()) != 64 and len(commit.stem.strip()) != 10:
+        raise exceptions.InvalidArgumentError(
+            "Invalid commit file name. Please provide a shortened, 10 character commit hash or the full 64 character commit hash as the commit identifier."
+        )
+
+    objects_dir = cwd / ".sccs" / "objects" / folder
+
+    for file in objects_dir.iterdir():
+        if str(file.stem).startswith(str(commit)):
+            commit = file
+
+    if not commit.is_file():
+         raise exceptions.InvalidArgumentError(
+            f"Commit file '{commit}' does not exist. Please provide a valid commit file"
+            f" path."
+        )
+    
+    return commit


### PR DESCRIPTION
# Use 10 Character Hash For Args #135 

This PR focuses on allowing users to input shortened, 10 character commit hashes instead of the entire commit pathname. It also updates `sccs log`, which now only prints 10 character hashes.

## Utils.py

- Create function `utils.validate_commit`, which convert a 10-character commit hash into a full commit pathname.

## Diff, Open, Revert

- Remove file-specific function which resolve the entered commit to the correct path.
- Use `utils.validate_commit` instead.

## Log.py

- Print 10 character commit hash instead of 64 character hash.

## Type of Change

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
