### PR TITLE
fix: convert path to str before strip

### DIFF
--- a/commands/utils.py
+++ b/commands/utils.py
@@ -572,7 +572,7 @@ def validate_commit(
 ) -> Path:
     """Validate the commit file path entered by the user."""
 
-    commit = Path(commit.strip()) if commit else None
+    commit = Path(str(commit).strip()) if commit else None
 
     if cwd is None:
         cwd = working_directory_path


### PR DESCRIPTION
# Fix AttributeError with `utils.validate_commit()`

This PR resolves an AttributeError which was occurring whenever `utils.validate_commit()` was called. The error occurred because .strip was called on a PosixPath instead of first converting to string. 

## Solution

Convert PosixPath to string before stripping whitespace