### PR TITLE
feat: add .history/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,6 @@ pyrightconfig.json
 # Test Files
 test_data/
 sample_document/
+
+# VS Code Local History Extension
+.history/


### PR DESCRIPTION
Add `.history/` to `gitignore` to ignore files created by the Local History VS Code Extension.