### PR TITLE
fix: update list of tags to unwrap to allow for functional diff with tables / lists

### DIFF
--- a/commands/diff.py
+++ b/commands/diff.py
@@ -152,7 +152,7 @@ def remove_inline_semantics(html: BeautifulSoup) -> BeautifulSoup:
     HTML."""
 
     soup = html
-    for tag in soup.find_all(["b", "i", "u", "strong", "em", "style"]):
+    for tag in soup.find_all(["b", "i", "u", "strong", "em", "style", "table", "tr", "td", "ol", "ul"]):
         if tag.name == "style":
             tag.decompose()
         else:

--- a/commands/diff.py
+++ b/commands/diff.py
@@ -152,7 +152,9 @@ def remove_inline_semantics(html: BeautifulSoup) -> BeautifulSoup:
     HTML."""
 
     soup = html
-    for tag in soup.find_all(["b", "i", "u", "strong", "em", "style", "table", "tr", "td", "ol", "ul"]):
+    for tag in soup.find_all(
+        ["b", "i", "u", "strong", "em", "style", "table", "tr", "td", "ol", "ul"]
+    ):
         if tag.name == "style":
             tag.decompose()
         else:


### PR DESCRIPTION
# Closes #147 

This PR solves #147 by unwrapping add `table`, `td`, `tr`, `ul`, and `ol` to the list of invalid tags that require unwrapping, because letting those tags wrap other HTML will create duplicated and unreadable content in the sccs diff-created `redline.html` file.

**Note:** While #147 implies that this is a new issue that was created since #37 was merged, I have came to the conclusion that this has **always** been an issue.

## diff.py

- Add `table`, `td`, `tr`, `ul`, and `ol` to the list of invalid tags that require unwrapping

## Type of Change

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
