### PR TITLE
Bugfix/#139 bug running open branch revert with uncommitted changes is allowed

### DIFF
--- a/commands/branch.py
+++ b/commands/branch.py
@@ -34,7 +34,8 @@ def validate_subcommand(subcommand: str | None, branch_name: str | None) -> None
     """
     Validate the subcommand entered by the user.
 
-    Raise an exception if the subcommand is invalid or if required arguments are missing.
+    Raise an exception if the subcommand is invalid or if required arguments are 
+    missing.
     """
 
     if not subcommand:

--- a/commands/branch.py
+++ b/commands/branch.py
@@ -257,6 +257,8 @@ def main() -> None:
 
     validate_subcommand(get_entered_subcommand(), get_entered_branch_name())
 
+    utils.check_for_uncommitted_changes("branch")
+
     run_specified_subcommand(
         get_entered_subcommand(),
         utils.get_current_branch(),

--- a/commands/branch.py
+++ b/commands/branch.py
@@ -34,7 +34,7 @@ def validate_subcommand(subcommand: str | None, branch_name: str | None) -> None
     """
     Validate the subcommand entered by the user.
 
-    Raise an exception if the subcommand is invalid or if required arguments are 
+    Raise an exception if the subcommand is invalid or if required arguments are
     missing.
     """
 

--- a/commands/diff.py
+++ b/commands/diff.py
@@ -257,7 +257,8 @@ def get_opcodes(
     Use difflib.SequenceMatcher to compare the two lists of tags and return a list of
     opcodes representing the differences between the 2 lists.
 
-    Return a list of opcodes representing the differences between the commit and current version HTML.
+    Return a list of opcodes representing the differences between the commit and current
+    version HTML.
     """
 
     commit_tags = tags_to_list(remove_inline_semantics(copy.copy(commit_soup)))
@@ -284,8 +285,8 @@ def format_redline_html(
     docx_current_version_list: list[str],
 ) -> BeautifulSoup:
     """
-    Use the list of opcodes provided to modify the base redline HTML. 'opcodes' is a list
-    of 5-tuples.
+    Use the list of opcodes provided to modify the base redline HTML. 'opcodes' is a 
+    list of 5-tuples.
 
     The first value in the 5-tuple is the type of difference. Depending on
     the type of difference, perform a different function:

--- a/commands/diff.py
+++ b/commands/diff.py
@@ -285,7 +285,7 @@ def format_redline_html(
     docx_current_version_list: list[str],
 ) -> BeautifulSoup:
     """
-    Use the list of opcodes provided to modify the base redline HTML. 'opcodes' is a 
+    Use the list of opcodes provided to modify the base redline HTML. 'opcodes' is a
     list of 5-tuples.
 
     The first value in the 5-tuple is the type of difference. Depending on

--- a/commands/open.py
+++ b/commands/open.py
@@ -65,6 +65,7 @@ def print_rewrite_confirmation_message(
         f"'{commit_path.name}'."
     )
 
+
 def main() -> None:
     """Run functions for the <sccs open> command."""
 

--- a/commands/open.py
+++ b/commands/open.py
@@ -39,22 +39,6 @@ def confirm_before_proceeding(
         sys.exit(0)
 
 
-def check_changes(commit_path: Path, docx_path: Path | None = None) -> None:
-    """
-    Check if the commit_path and docx_path refer to the same file.
-
-    If so, print a message telling the user that no changes will be made and exit with
-    exit code 0.
-    """
-    if docx_path is None:
-        docx_path = utils.current_file_docx_path
-    if docx_path.exists() and commit_path.exists() and docx_path.samefile(commit_path):
-        print(
-            "The commit file is the same as the current file. No changes will be made."
-        )
-        sys.exit(0)
-
-
 def copy_file_commit(commit_path: Path, docx_path: Path | None = None) -> None:
     """
     Copy the commit file to the current document, effectively opening the older commit.
@@ -81,7 +65,6 @@ def print_rewrite_confirmation_message(
         f"'{commit_path.name}'."
     )
 
-
 def main() -> None:
     """Run functions for the <sccs open> command."""
 
@@ -91,7 +74,7 @@ def main() -> None:
         "docx", utils.working_directory_path, get_commit_path_input()
     )
 
-    check_changes(commit_path)
+    utils.check_for_uncommitted_changes("open")
 
     confirm_before_proceeding(commit_path)
 

--- a/commands/revert.py
+++ b/commands/revert.py
@@ -30,7 +30,8 @@ def print_revert_confirmation_message(commit: Path, new_commit_hash: str) -> Non
     """Print a confirmation message for the revert."""
 
     print(
-        f"Document successfully reverted to commit '{commit.stem}' on commit '{new_commit_hash}'."
+        f"Document successfully reverted to commit '{commit.stem}' on commit "
+        f"'{new_commit_hash}'."
     )
 
 

--- a/commands/revert.py
+++ b/commands/revert.py
@@ -38,6 +38,8 @@ def main() -> None:
     """Main function to handle the revert command."""
     utils.check_sccs_layout()
 
+    utils.check_for_uncommitted_changes("revert")
+
     cwd = utils.working_directory_path
     commit = get_entered_commit()
     validated_commit = utils.validate_commit("docx", cwd, commit)

--- a/commands/switch.py
+++ b/commands/switch.py
@@ -82,20 +82,6 @@ def get_latest_commit_binary_hash(
         raise exceptions.FileOpenError from e
 
 
-def check_for_changes(
-    branch: str, latest_commit_binary_hash: str, current_document_hash: str
-) -> None:
-    """
-    Check if there are uncommitted changes on the current branch by comparing the
-    current document hash and the latest commit hash.
-    """
-    if not current_document_hash == latest_commit_binary_hash:
-        raise exceptions.UncommittedChangesError(
-            f"The current file has uncommitted changes on the current branch '{branch}'"
-            f". Please commit your changes before switching branches."
-        )
-
-
 def sanitize_branch(branch_name: str) -> str:
     """Sanitize the branch name."""
     return utils.clean_directory_name(branch_name)
@@ -166,7 +152,7 @@ def main() -> None:
 
     current_document_hash = utils.hash_current_docx_binary()
 
-    check_for_changes(current_branch, latest_commit_binary_hash, current_document_hash)
+    utils.check_for_uncommitted_changes("switch")
 
     branch_to_switch = get_branch_to_switch()
 

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -643,15 +643,12 @@ def validate_commit(
 
     return matching_files[0]
 
-def check_for_uncommitted_changes(cmd, cwd: Path | None = None) -> bool:
+def check_for_uncommitted_changes(cmd, cwd: Path | None = None) -> None:
     """
     Check for uncommitted changes by hashing the current document bytes and comparing 
     that to the latest commit bytes hash from the SCCS metadata.
     
     'cmd' is the command being run. It is used in the exception message. 
-
-    Return True if uncommitted changes exist, return False if there are no uncommitted
-    changes.
     """
 
     if cwd is None:

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -643,12 +643,17 @@ def validate_commit(
 
     return matching_files[0]
 
-def check_for_uncommitted_changes(cmd, cwd: Path | None = None) -> None:
+def check_for_uncommitted_changes(cmd, exit: bool = True, cwd: Path | None = None) -> None:
     """
     Check for uncommitted changes by hashing the current document bytes and comparing 
     that to the latest commit bytes hash from the SCCS metadata.
     
     'cmd' is the command being run. It is used in the exception message. 
+
+    If 'exit' is false and uncommitted changes were found, return True, if not return 
+    False.
+
+    'exit' defaults to True.
     """
 
     if cwd is None:
@@ -675,10 +680,12 @@ def check_for_uncommitted_changes(cmd, cwd: Path | None = None) -> None:
         ) as f:
         data = f.read
         latest_bytes_hash = data[""][latest_commit]
+
+    if exit:
+        if not latest_bytes_hash == hash_current_docx_binary():
+            raise exceptions.UncommittedChangesError(f"Uncommitted changes were found. Please commit before running <sccs {cmd}>")
         
-    if not latest_bytes_hash == hash_current_docx_binary():
-        raise exceptions.UncommittedChangesError(f"Uncommitted changes were found. Please commit before running <sccs {cmd}>")
-        
-        
+    else:
+        return True if not latest_bytes_hash == hash_current_docx_binary else False
 
 

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -643,17 +643,20 @@ def validate_commit(
 
     return matching_files[0]
 
-def check_for_uncommitted_changes(cmd, exit: bool = True, cwd: Path | None = None) -> None:
+
+def check_for_uncommitted_changes(
+    cmd, exit: bool = True, cwd: Path | None = None
+) -> None:
     """
-    Check for uncommitted changes by hashing the current document bytes and comparing 
+    Check for uncommitted changes by hashing the current document bytes and comparing
     that to the latest commit bytes hash from the SCCS metadata.
-    
-    'cmd' is the command being run. It is used in the exception message. 
-    
+
+    'cmd' is the command being run. It is used in the exception message.
+
     If exit is true, raise an UncommittedChangesError if uncommitted changes were found,
     if not return None.
 
-    If 'exit' is false and uncommitted changes were found, return True, if not return 
+    If 'exit' is false and uncommitted changes were found, return True, if not return
     False.
 
     'exit' defaults to True.
@@ -661,34 +664,34 @@ def check_for_uncommitted_changes(cmd, exit: bool = True, cwd: Path | None = Non
 
     if cwd is None:
         cwd = working_directory_path
-    
+
     with open(
-        cwd /
-        ".sccs" /
-        "branches" /
-        get_current_branch() /
-        "history" /
-        "commit_history.json"
-        ) as f:
+        cwd
+        / ".sccs"
+        / "branches"
+        / get_current_branch()
+        / "history"
+        / "commit_history.json"
+    ) as f:
         data = json.load(f)
         latest_commit = data["history"]["latest_commit"]
 
     with open(
-        cwd /
-        ".sccs" /
-        "branches" /
-        get_current_branch() /
-        "commit_file_hash" /
-        "commit_file_hash.json"
-        ) as f:
+        cwd
+        / ".sccs"
+        / "branches"
+        / get_current_branch()
+        / "commit_file_hash"
+        / "commit_file_hash.json"
+    ) as f:
         data = json.load(f)
         latest_bytes_hash = data[latest_commit]
 
     if exit:
         if not latest_bytes_hash == hash_current_docx_binary():
-            raise exceptions.UncommittedChangesError(f"Uncommitted changes were found. Please commit before running <sccs {cmd}>")
-        
+            raise exceptions.UncommittedChangesError(
+                f"Uncommitted changes were found. Please commit before running <sccs {cmd}>"
+            )
+
     else:
         return True if not latest_bytes_hash == hash_current_docx_binary else False
-
-

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -685,10 +685,10 @@ def check_for_uncommitted_changes(cmd: str, exit: bool = True, cwd: Path | None 
         latest_bytes_hash = data[latest_commit]
 
     if exit:
-        if not latest_bytes_hash == hash_current_docx_binary():
-            raise exceptions.UncommittedChangesError(
-                f"Uncommitted changes were found. Please commit before running <sccs {cmd}>"
-            )
-
+        if latest_bytes_hash != hash_current_docx_binary():
+            raise exceptions.UncommittedChangesError(f"Uncommitted changes were found. Please commit before running <sccs {cmd}>")
+        
     else:
-        return True if not latest_bytes_hash == hash_current_docx_binary else False
+        return True if latest_bytes_hash != hash_current_docx_binary() else False
+
+

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -657,29 +657,29 @@ def check_for_uncommitted_changes(cmd, exit: bool = True, cwd: Path | None = Non
     """
 
     if cwd is None:
-        cwd = working_directory_path()
+        cwd = working_directory_path
     
     with open(
         cwd /
         ".sccs" /
         "branches" /
-        get_current_branch /
+        get_current_branch() /
         "history" /
         "commit_history.json"
         ) as f:
-        data = f.read
+        data = json.load(f)
         latest_commit = data["history"]["latest_commit"]
 
     with open(
         cwd /
         ".sccs" /
         "branches" /
-        get_current_branch /
+        get_current_branch() /
         "commit_file_hash" /
         "commit_file_hash.json"
         ) as f:
-        data = f.read
-        latest_bytes_hash = data[""][latest_commit]
+        data = json.load(f)
+        latest_bytes_hash = data[latest_commit]
 
     if exit:
         if not latest_bytes_hash == hash_current_docx_binary():

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -643,7 +643,10 @@ def validate_commit(
 
     return matching_files[0]
 
-def check_for_uncommitted_changes(cmd: str, exit: bool = True, cwd: Path | None = None) -> None | bool:
+
+def check_for_uncommitted_changes(
+    cmd: str, exit: bool = True, cwd: Path | None = None
+) -> None | bool:
     """
     Check for uncommitted changes by hashing the current document bytes and comparing
     that to the latest commit bytes hash from the SCCS metadata.
@@ -663,32 +666,36 @@ def check_for_uncommitted_changes(cmd: str, exit: bool = True, cwd: Path | None 
         cwd = working_directory_path
 
     with open(
-        cwd /
-        ".sccs" /
-        "branches" /
-        get_current_branch() /
-        "history" /
-        "commit_history.json", encoding="utf-8", newline="\n"
-        ) as f:
+        cwd
+        / ".sccs"
+        / "branches"
+        / get_current_branch()
+        / "history"
+        / "commit_history.json",
+        encoding="utf-8",
+        newline="\n",
+    ) as f:
         data = json.load(f)
         latest_commit = data["history"]["latest_commit"]
 
     with open(
-        cwd /
-        ".sccs" /
-        "branches" /
-        get_current_branch() /
-        "commit_file_hash" /
-        "commit_file_hash.json", encoding="utf-8", newline="\n"
-        ) as f:
+        cwd
+        / ".sccs"
+        / "branches"
+        / get_current_branch()
+        / "commit_file_hash"
+        / "commit_file_hash.json",
+        encoding="utf-8",
+        newline="\n",
+    ) as f:
         data = json.load(f)
         latest_bytes_hash = data[latest_commit]
 
     if exit:
         if latest_bytes_hash != hash_current_docx_binary():
-            raise exceptions.UncommittedChangesError(f"Uncommitted changes were found. Please commit before running <sccs {cmd}>")
-        
+            raise exceptions.UncommittedChangesError(
+                f"Uncommitted changes were found. Please commit before running <sccs {cmd}>"
+            )
+
     else:
         return True if latest_bytes_hash != hash_current_docx_binary() else False
-
-

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -647,9 +647,10 @@ def validate_commit(
 
     return matching_files[0]
 
+
 def check_for_uncommitted_changes(
-        cmd: str, exit: bool = True, cwd: Path | None = None
-    ) -> None | bool:
+    cmd: str, exit: bool = True, cwd: Path | None = None
+) -> None | bool:
     """
     Check for uncommitted changes by hashing the current document bytes and comparing
     that to the latest commit bytes hash from the SCCS metadata.
@@ -700,6 +701,6 @@ def check_for_uncommitted_changes(
                 f"Uncommitted changes were found. Please commit before running <sccs "
                 f"{cmd}>"
             )
-        
+
     else:
         return True if latest_bytes_hash != hash_current_docx_binary() else False

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -643,12 +643,12 @@ def validate_commit(
 
     return matching_files[0]
 
-def check_for_uncommitted_changes(cwd: Path | None = None) -> bool:
+def do_uncommitted_changes_exist(cwd: Path | None = None) -> bool:
     """
     Check for uncommitted changes by hashing the current document bytes and comparing 
     that to the latest commit bytes hash from the SCCS metadata.
 
-    Return False if uncommitted changes exist, return True if there are no uncommitted
+    Return True if uncommitted changes exist, return False if there are no uncommitted
     changes.
     """
 
@@ -678,9 +678,9 @@ def check_for_uncommitted_changes(cwd: Path | None = None) -> bool:
         latest_bytes_hash = data[""][latest_commit]
         
     if latest_bytes_hash == hash_current_docx_binary():
-        return True
-    else:
         return False
+    else:
+        return True
         
         
 

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -241,7 +241,9 @@ def get_branch_data(
 
 
 def convert_docx_to_html(docx_path: Path | None = None) -> str:
-    """Convert a DOCX document to using HTML and return the generated HTML as a string."""
+    """
+    Convert a DOCX document to HTML and return the generated HTML as a string.
+    """
     if docx_path is None:
         docx_path = current_file_docx_path
     try:
@@ -618,7 +620,8 @@ def validate_commit(
 
     if len(commit.stem.strip()) != 64 and len(commit.stem.strip()) != 10:
         raise exceptions.InvalidArgumentError(
-            "Invalid commit file name. Please provide a shortened, 10 character commit hash or the full 64 character commit hash as the commit identifier."
+            "Invalid commit file name. Please provide a shortened, 10 character commit "
+            "hash or the full 64 character commit hash as the commit identifier."
         )
 
     objects_dir = cwd / ".sccs" / "objects" / folder
@@ -638,15 +641,15 @@ def validate_commit(
 
     if len(matching_files) > 1:
         raise exceptions.InvalidArgumentError(
-            f"Multiple commit files found matching '{commit}'. Please provide a full, 64 character commit hash."
+            f"Multiple commit files found matching '{commit}'. Please provide a full, "
+            f"64 character commit hash."
         )
 
     return matching_files[0]
 
-
 def check_for_uncommitted_changes(
-    cmd: str, exit: bool = True, cwd: Path | None = None
-) -> None | bool:
+        cmd: str, exit: bool = True, cwd: Path | None = None
+    ) -> None | bool:
     """
     Check for uncommitted changes by hashing the current document bytes and comparing
     that to the latest commit bytes hash from the SCCS metadata.
@@ -694,8 +697,9 @@ def check_for_uncommitted_changes(
     if exit:
         if latest_bytes_hash != hash_current_docx_binary():
             raise exceptions.UncommittedChangesError(
-                f"Uncommitted changes were found. Please commit before running <sccs {cmd}>"
+                f"Uncommitted changes were found. Please commit before running <sccs "
+                f"{cmd}>"
             )
-
+        
     else:
         return True if latest_bytes_hash != hash_current_docx_binary() else False

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -643,10 +643,7 @@ def validate_commit(
 
     return matching_files[0]
 
-
-def check_for_uncommitted_changes(
-    cmd, exit: bool = True, cwd: Path | None = None
-) -> None:
+def check_for_uncommitted_changes(cmd: str, exit: bool = True, cwd: Path | None = None) -> None | bool:
     """
     Check for uncommitted changes by hashing the current document bytes and comparing
     that to the latest commit bytes hash from the SCCS metadata.

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -663,24 +663,24 @@ def check_for_uncommitted_changes(cmd: str, exit: bool = True, cwd: Path | None 
         cwd = working_directory_path
 
     with open(
-        cwd
-        / ".sccs"
-        / "branches"
-        / get_current_branch()
-        / "history"
-        / "commit_history.json"
-    ) as f:
+        cwd /
+        ".sccs" /
+        "branches" /
+        get_current_branch() /
+        "history" /
+        "commit_history.json", encoding="utf-8", newline="\n"
+        ) as f:
         data = json.load(f)
         latest_commit = data["history"]["latest_commit"]
 
     with open(
-        cwd
-        / ".sccs"
-        / "branches"
-        / get_current_branch()
-        / "commit_file_hash"
-        / "commit_file_hash.json"
-    ) as f:
+        cwd /
+        ".sccs" /
+        "branches" /
+        get_current_branch() /
+        "commit_file_hash" /
+        "commit_file_hash.json", encoding="utf-8", newline="\n"
+        ) as f:
         data = json.load(f)
         latest_bytes_hash = data[latest_commit]
 

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -642,3 +642,46 @@ def validate_commit(
         )
 
     return matching_files[0]
+
+def check_for_uncommitted_changes(cwd: Path | None = None) -> bool:
+    """
+    Check for uncommitted changes by hashing the current document bytes and comparing 
+    that to the latest commit bytes hash from the SCCS metadata.
+
+    Return False if uncommitted changes exist, return True if there are no uncommitted
+    changes.
+    """
+
+    if cwd is None:
+        cwd = working_directory_path()
+    
+    with open(
+        cwd /
+        ".sccs" /
+        "branches" /
+        get_current_branch /
+        "history" /
+        "commit_history.json"
+        ) as f:
+        data = f.read
+        latest_commit = data["history"]["latest_commit"]
+
+    with open(
+        cwd /
+        ".sccs" /
+        "branches" /
+        get_current_branch /
+        "commit_file_hash" /
+        "commit_file_hash.json"
+        ) as f:
+        data = f.read
+        latest_bytes_hash = data[""][latest_commit]
+        
+    if latest_bytes_hash == hash_current_docx_binary():
+        return True
+    else:
+        return False
+        
+        
+
+

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -643,10 +643,12 @@ def validate_commit(
 
     return matching_files[0]
 
-def do_uncommitted_changes_exist(cwd: Path | None = None) -> bool:
+def check_for_uncommitted_changes(cmd, cwd: Path | None = None) -> bool:
     """
     Check for uncommitted changes by hashing the current document bytes and comparing 
     that to the latest commit bytes hash from the SCCS metadata.
+    
+    'cmd' is the command being run. It is used in the exception message. 
 
     Return True if uncommitted changes exist, return False if there are no uncommitted
     changes.
@@ -677,10 +679,8 @@ def do_uncommitted_changes_exist(cwd: Path | None = None) -> bool:
         data = f.read
         latest_bytes_hash = data[""][latest_commit]
         
-    if latest_bytes_hash == hash_current_docx_binary():
-        return False
-    else:
-        return True
+    if not latest_bytes_hash == hash_current_docx_binary():
+        raise exceptions.UncommittedChangesError(f"Uncommitted changes were found. Please commit before running <sccs {cmd}>")
         
         
 

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -649,6 +649,9 @@ def check_for_uncommitted_changes(cmd, exit: bool = True, cwd: Path | None = Non
     that to the latest commit bytes hash from the SCCS metadata.
     
     'cmd' is the command being run. It is used in the exception message. 
+    
+    If exit is true, raise an UncommittedChangesError if uncommitted changes were found,
+    if not return None.
 
     If 'exit' is false and uncommitted changes were found, return True, if not return 
     False.


### PR DESCRIPTION
# Closes #139 

This PR creates a new function that checks for uncommitted changes. This functions is implemented in open.py, branch.py, revert.py, and switch.py to block users from running certain commands when they have uncommitted changes. 

The functions has 1 parameter, `exit`. 
- If `exit` is true, raise an UncommittedChangesError if uncommitted changes were found, if not return None. 
- If `exit` is false and uncommitted changes were found, return True, if not return False.
- **`exit` is True by default.**

## Type of Change

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
