### PR TITLE
Feat/#141 feature create sccs reset command

### DIFF
--- a/commands/exceptions.py
+++ b/commands/exceptions.py
@@ -181,6 +181,10 @@ class UncommittedChangesError(SCCSException):
 
     default_message = "Uncommitted changes prevent this action."
 
+class NoUncommittedChangesError(SCCSException):
+    """Raised when there are no uncommitted changes but an action requires them."""
+
+    default_message = "No uncommitted changes found."    
 
 # Input Exceptions
 

--- a/commands/exceptions.py
+++ b/commands/exceptions.py
@@ -181,10 +181,12 @@ class UncommittedChangesError(SCCSException):
 
     default_message = "Uncommitted changes prevent this action."
 
+
 class NoUncommittedChangesError(SCCSException):
     """Raised when there are no uncommitted changes but an action requires them."""
 
-    default_message = "No uncommitted changes found."    
+    default_message = "No uncommitted changes found."
+
 
 # Input Exceptions
 

--- a/commands/reset.py
+++ b/commands/reset.py
@@ -16,7 +16,7 @@ def reset(cwd: Path | None = None) -> None:
     if cwd is None:
         cwd = utils.working_directory_path
 
-    if not utils.check_for_uncommitted_changes(cwd, "reset", exit=False):
+    if not utils.check_for_uncommitted_changes("reset", exit=False, cwd=cwd):
         raise exceptions.NoUncommittedChangesError()
 
     with open(

--- a/commands/reset.py
+++ b/commands/reset.py
@@ -23,7 +23,9 @@ def reset(cwd: Path | None = None) -> None:
         cwd
         / ".sccs"
         / "branches"
-        / utils.get_current_branch()
+        / utils.get_current_branch(
+            cwd / ".sccs" / "current_branch" / "current_branch.json"
+        )
         / "history"
         / "commit_history.json"
     ) as f:
@@ -31,7 +33,7 @@ def reset(cwd: Path | None = None) -> None:
         latest_commit = data["history"]["latest_commit"]
 
     shutil.copy2(
-        utils.validate_commit("docx", cwd, latest_commit), utils.current_file_docx_path
+        utils.validate_commit("docx", cwd, latest_commit), cwd / cwd.with_suffix(".docx").name
     )
 
 

--- a/commands/reset.py
+++ b/commands/reset.py
@@ -25,10 +25,19 @@ def reset(cwd: Path | None = None) -> None:
     shutil.copy2(utils.validate_commit(folder="docx", commit=latest_commit), cwd / utils.current_file_docx_path)
 
 
+def print_success_message() -> None:
+    """Print a success message after resetting the document."""
+    print(
+        "All uncommitted changes have been deleted. The document has been reset to the "
+        "latest commit."
+    )
+
+
 def main() -> None:
     """Main function to handle the <reset> command."""
     utils.check_sccs_layout()
     reset()
+    print_success_message()
     
 
 if __name__ == "__main__":

--- a/commands/reset.py
+++ b/commands/reset.py
@@ -16,7 +16,7 @@ def reset(cwd: Path | None = None) -> None:
     if cwd is None:
         cwd = utils.working_directory_path
 
-    if not utils.check_for_uncommitted_changes("reset", exit=False):
+    if not utils.check_for_uncommitted_changes(cwd, "reset", exit=False):
         raise exceptions.NoUncommittedChangesError()
 
     with open(
@@ -29,11 +29,8 @@ def reset(cwd: Path | None = None) -> None:
     ) as f:
         data = json.load(f)
         latest_commit = data["history"]["latest_commit"]
-
-    shutil.copy2(
-        utils.validate_commit(folder="docx", commit=latest_commit),
-        cwd / utils.current_file_docx_path,
-    )
+        
+    shutil.copy2(utils.validate_commit("docx", cwd, latest_commit), utils.current_file_docx_path)
 
 
 def print_success_message() -> None:

--- a/commands/reset.py
+++ b/commands/reset.py
@@ -22,7 +22,7 @@ def reset(cwd: Path | None = None) -> None:
         data = json.load(f)
         latest_commit = data["history"]["latest_commit"]
         
-    shutil.copy2(utils.validate_commit("docx", latest_commit), cwd / utils.current_file_docx_path())
+    shutil.copy2(utils.validate_commit(folder="docx", commit=latest_commit), cwd / utils.current_file_docx_path)
 
 
 def main() -> None:

--- a/commands/reset.py
+++ b/commands/reset.py
@@ -33,7 +33,8 @@ def reset(cwd: Path | None = None) -> None:
         latest_commit = data["history"]["latest_commit"]
 
     shutil.copy2(
-        utils.validate_commit("docx", cwd, latest_commit), cwd / cwd.with_suffix(".docx").name
+        utils.validate_commit("docx", cwd, latest_commit),
+        cwd / cwd.with_suffix(".docx").name,
     )
 
 

--- a/commands/reset.py
+++ b/commands/reset.py
@@ -1,28 +1,39 @@
 #!/usr/bin/env python3
 """Delete all uncommitted changes."""
 
+import json
 import shutil
 import sys
 from pathlib import Path
+
 import exceptions
 import utils
-import json
 
 
 def reset(cwd: Path | None = None) -> None:
     """Delete all uncommitted changes."""
-    
+
     if cwd is None:
         cwd = utils.working_directory_path
 
     if not utils.check_for_uncommitted_changes("reset", exit=False):
         raise exceptions.NoUncommittedChangesError()
-        
-    with open(cwd / ".sccs" / "branches" / utils.get_current_branch() / "history" / "commit_history.json") as f:
+
+    with open(
+        cwd
+        / ".sccs"
+        / "branches"
+        / utils.get_current_branch()
+        / "history"
+        / "commit_history.json"
+    ) as f:
         data = json.load(f)
         latest_commit = data["history"]["latest_commit"]
-        
-    shutil.copy2(utils.validate_commit(folder="docx", commit=latest_commit), cwd / utils.current_file_docx_path)
+
+    shutil.copy2(
+        utils.validate_commit(folder="docx", commit=latest_commit),
+        cwd / utils.current_file_docx_path,
+    )
 
 
 def print_success_message() -> None:
@@ -38,7 +49,7 @@ def main() -> None:
     utils.check_sccs_layout()
     reset()
     print_success_message()
-    
+
 
 if __name__ == "__main__":
     try:

--- a/commands/reset.py
+++ b/commands/reset.py
@@ -30,7 +30,9 @@ def reset(cwd: Path | None = None) -> None:
         data = json.load(f)
         latest_commit = data["history"]["latest_commit"]
         
-    shutil.copy2(utils.validate_commit("docx", cwd, latest_commit), utils.current_file_docx_path)
+    shutil.copy2(
+        utils.validate_commit("docx", cwd, latest_commit), utils.current_file_docx_path
+    )
 
 
 def print_success_message() -> None:

--- a/commands/reset.py
+++ b/commands/reset.py
@@ -15,7 +15,7 @@ def reset(cwd: Path | None = None) -> None:
     if cwd is None:
         cwd = utils.working_directory_path
 
-    if not utils.check_for_uncommitted_changes("reset", False):
+    if not utils.check_for_uncommitted_changes("reset", exit=False):
         raise exceptions.NoUncommittedChangesError()
         
     with open(cwd / ".sccs" / "branches" / utils.get_current_branch() / "history" / "commit_history.json") as f:

--- a/commands/reset.py
+++ b/commands/reset.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Delete all uncommitted changes."""
+
+import shutil
+import sys
+from pathlib import Path
+import exceptions
+import utils
+import json
+
+
+def reset(cwd: Path | None = None) -> None:
+    """Delete all uncommitted changes."""
+    
+    if cwd is None:
+        cwd = utils.working_directory_path
+
+    if not utils.check_for_uncommitted_changes("reset", False):
+        raise exceptions.NoUncommittedChangesError()
+        
+    with open(cwd / ".sccs" / "branches" / utils.get_current_branch() / "history" / "commit_history.json") as f:
+        data = json.load(f)
+        latest_commit = data["history"]["latest_commit"]
+        
+    shutil.copy2(utils.validate_commit("docx", latest_commit), cwd / utils.current_file_docx_path())
+
+
+def main() -> None:
+    """Main function to handle the <reset> command."""
+    utils.check_sccs_layout()
+    reset()
+    
+
+if __name__ == "__main__":
+    try:
+        main()
+    except exceptions.SCCSException as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"An unexpected error occurred:\n{e}\n")
+        sys.exit(1)

--- a/commands/reset.py
+++ b/commands/reset.py
@@ -29,7 +29,7 @@ def reset(cwd: Path | None = None) -> None:
     ) as f:
         data = json.load(f)
         latest_commit = data["history"]["latest_commit"]
-        
+
     shutil.copy2(
         utils.validate_commit("docx", cwd, latest_commit), utils.current_file_docx_path
     )

--- a/commands/sccs
+++ b/commands/sccs
@@ -21,6 +21,7 @@ COMMANDS = [
     "clone",
     "config",
     "revert"
+    "reset"
 ]
 
 
@@ -56,7 +57,7 @@ def execute_command(command: str, script_directory: Path, COMMANDS: list) -> Non
     if command not in COMMANDS:
         raise exceptions.UnknownCommandError(
             f"Unknown command: {command}. Please use 'init', 'commit', 'open', 'log', "
-            f"'diff', 'status', 'help', 'branch', 'switch', 'clone', 'config', or "
+            f"'diff', 'status', 'help', 'branch', 'switch', 'clone', 'config', 'reset', or "
             f"'publish', along with required arguments. For help, use the 'sccs help' "
             f"command."
         )

--- a/commands/sccs
+++ b/commands/sccs
@@ -20,7 +20,7 @@ COMMANDS = [
     "publish",
     "clone",
     "config",
-    "revert"
+    "revert",
     "reset"
 ]
 

--- a/commands/sccs
+++ b/commands/sccs
@@ -57,7 +57,7 @@ def execute_command(command: str, script_directory: Path, COMMANDS: list) -> Non
     if command not in COMMANDS:
         raise exceptions.UnknownCommandError(
             f"Unknown command: {command}. Please use 'init', 'commit', 'open', 'log', "
-            f"'diff', 'status', 'help', 'branch', 'switch', 'clone', 'config', 'reset', or "
+            f"'diff', 'status', 'help', 'branch', 'switch', 'clone', 'config', 'revert', 'reset', or "
             f"'publish', along with required arguments. For help, use the 'sccs help' "
             f"command."
         )

--- a/commands/sccs.bat
+++ b/commands/sccs.bat
@@ -81,7 +81,13 @@ if "%command%"=="revert" (
     exit /b !errorlevel!
 )
 
+if "%command%"=="reset" (
+    set "script_directory=%~dp0"
+    python "%script_directory%reset.py" %*
+    exit /b !errorlevel!
+)
+
 echo Unknown command: %command%
-echo Invalid command. Please use "init", "commit", "open", "log", "status", "diff", "help", "branch", "switch", "publish", "clone", or "config", along with required arguments
+echo Invalid command. Please use "init", "commit", "open", "log", "status", "diff", "help", "branch", "switch", "publish", "clone", "config", "revert", or "reset", along with required arguments
 echo For help, use the 'sccs help' command
 exit /b 1


### PR DESCRIPTION
# Closes #141 

This PR creates a new command for the SCCS CLI, `sccs reset` which deletes uncommitted changes.

## SCCS, SCCS.bat

- Add tunnels to reset.py for `sccs reset`.

## Reset.py

- Use `utils.check_for_uncommitted_changes(exit=false)` to check for uncommitted changes without exiting if they exist.
- Copy the latest commit to the current document, overwriting uncommitted changes.

## Type of Change

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
