### PR TITLE
Feat/#127 feature sccs pull command

### DIFF
--- a/API/main.py
+++ b/API/main.py
@@ -246,20 +246,20 @@ async def push_upload(repo_name: str, file: UploadFile = File(...)) -> dict:
 @app.post("/repos/{repo_name}/pull")
 async def pull(repo_name: str, data: dict) -> StreamingResponse:
     """
-    Send a zip archive of commit objects and metadata files that the local repository 
-    (caller) is missing by accepting a list of commit objects that the local doesn't 
+    Send a zip archive of commit objects and metadata files that the local repository
+    (caller) is missing by accepting a list of commit objects that the local doesn't
     have.
     """
 
     repo_name = resolve_path(Path(repo_name))
     ensure_repository_exists(repo_name)
-    
+
     repo_path = (Path("API/repos").resolve() / repo_name).resolve()
 
     if (
-        not isinstance(data, dict) or
-        "objects" not in data or
-        not isinstance(data["objects"], list)
+        not isinstance(data, dict)
+        or "objects" not in data
+        or not isinstance(data["objects"], list)
     ):
         raise HTTPException(status_code=400, detail="Invalid JSON data")
 
@@ -272,10 +272,13 @@ async def pull(repo_name: str, data: dict) -> StreamingResponse:
     obj_to_upload = list(set(remote_objects) - set(local_objects))
 
     if list(set(local_objects) - set(remote_objects)):
-        raise HTTPException(status_code=400, detail=(
-            "Local repository has objects that the remote does not have. Run 'sccs push"
-            "' to upload these objects before pulling."
-        ))
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Local repository has objects that the remote does not have. Run 'sccs push"
+                "' to upload these objects before pulling."
+            ),
+        )
 
     document_path = [repo_path / f"{repo_path.name}.docx"]
     current_branch_path = [
@@ -292,14 +295,14 @@ async def pull(repo_name: str, data: dict) -> StreamingResponse:
     ]
 
     history_paths = [
-        f.resolve() for f in (
-            repo_path / ".sccs" / "branches"
-        ).rglob("*") if f.is_file() and f.stem == "history"
+        f.resolve()
+        for f in (repo_path / ".sccs" / "branches").rglob("*")
+        if f.is_file() and f.stem == "history"
     ]
     byte_hash_paths = [
-        f.resolve() for f in (
-            repo_path / ".sccs" / "branches"
-        ).rglob("*") if f.is_file() and f.stem == "commit_file_hash"
+        f.resolve()
+        for f in (repo_path / ".sccs" / "branches").rglob("*")
+        if f.is_file() and f.stem == "commit_file_hash"
     ]
 
     files_to_upload = (
@@ -310,7 +313,7 @@ async def pull(repo_name: str, data: dict) -> StreamingResponse:
         + current_branch_path
         + commit_msgs_path
     )
-        
+
     buffer = io.BytesIO()
     with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
         for file_path in files_to_upload:
@@ -319,7 +322,7 @@ async def pull(repo_name: str, data: dict) -> StreamingResponse:
     return StreamingResponse(
         buffer,
         media_type="application/zip",
-        headers={"Content-Disposition": f"attachment; filename={repo_name}.zip"}
+        headers={"Content-Disposition": f"attachment; filename={repo_name}.zip"},
     )
 
 

--- a/API/main.py
+++ b/API/main.py
@@ -272,12 +272,13 @@ async def pull(repo_name: str, data: dict) -> StreamingResponse:
     obj_to_upload = remote_objects - local_objects
 
     if local_objects - remote_objects:
-        raise HTTPException(status_code=400, detail=(
-            "Local repository has objects that the remote does not have. Run 'sccs push"
-            "' to upload these objects before pulling."
-        ))
-
-        
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Local repository has objects that the remote does not have. Run 'sccs push"
+                "' to upload these objects before pulling."
+            ),
+        )
 
     document_path = [repo_path / f"{repo_path.name}.docx"]
     current_branch_path = [
@@ -305,8 +306,8 @@ async def pull(repo_name: str, data: dict) -> StreamingResponse:
     ]
 
     files_to_upload = (
-        f for f in
-        objects_paths
+        f
+        for f in objects_paths
         + history_paths
         + byte_hash_paths
         + document_path

--- a/API/main.py
+++ b/API/main.py
@@ -276,9 +276,8 @@ async def pull(repo_name: str, data: dict) -> StreamingResponse:
             "Local repository has objects that the remote does not have. Run 'sccs push"
             "' to upload these objects before pulling."
         ))
-                "' to upload these objects before pulling."
-            ),
-        )
+
+        
 
     document_path = [repo_path / f"{repo_path.name}.docx"]
     current_branch_path = [

--- a/API/main.py
+++ b/API/main.py
@@ -263,19 +263,19 @@ async def pull(repo_name: str, data: dict) -> StreamingResponse:
     ):
         raise HTTPException(status_code=400, detail="Invalid JSON data")
 
-    local_objects = data["objects"]
+    local_objects = set(data["objects"])
 
-    remote_objects = list(
-        set(f.stem for f in (repo_path / ".sccs" / "objects").rglob("*") if f.is_file())
+    remote_objects = set(
+        f.stem for f in (repo_path / ".sccs" / "objects").rglob("*") if f.is_file()
     )
 
-    obj_to_upload = list(set(remote_objects) - set(local_objects))
+    obj_to_upload = remote_objects - local_objects
 
-    if list(set(local_objects) - set(remote_objects)):
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                "Local repository has objects that the remote does not have. Run 'sccs push"
+    if local_objects - remote_objects:
+        raise HTTPException(status_code=400, detail=(
+            "Local repository has objects that the remote does not have. Run 'sccs push"
+            "' to upload these objects before pulling."
+        ))
                 "' to upload these objects before pulling."
             ),
         )

--- a/API/main.py
+++ b/API/main.py
@@ -265,18 +265,25 @@ async def pull(repo_name: str, data: dict) -> StreamingResponse:
 
     local_objects = data["objects"]
 
-    remote_objects = list(set(f.stem for f in (repo_path / ".sccs" / "objects").rglob("*") if f.is_file()))
+    remote_objects = list(
+        set(f.stem for f in (repo_path / ".sccs" / "objects").rglob("*") if f.is_file())
+    )
 
     obj_to_upload = list(set(remote_objects) - set(local_objects))
 
     if list(set(local_objects) - set(remote_objects)):
-        raise HTTPException(status_code=400, detail="Local repository has objects that the remote does not have. Run 'sccs push' to upload these objects before pulling.")
-
-
+        raise HTTPException(status_code=400, detail=(
+            "Local repository has objects that the remote does not have. Run 'sccs push"
+            "' to upload these objects before pulling."
+        ))
 
     document_path = [repo_path / f"{repo_path.name}.docx"]
-    current_branch_path = [repo_path / ".sccs" / "current_branch" / "current_branch.json"]
-    commit_msgs_path = [repo_path / ".sccs" / "commit_messages" / "commit_messages.json"]
+    current_branch_path = [
+        repo_path / ".sccs" / "current_branch" / "current_branch.json"
+    ]
+    commit_msgs_path = [
+        repo_path / ".sccs" / "commit_messages" / "commit_messages.json"
+    ]
 
     objects_paths = [
         f.resolve()
@@ -284,8 +291,16 @@ async def pull(repo_name: str, data: dict) -> StreamingResponse:
         if f.is_file() and f.stem in obj_to_upload
     ]
 
-    history_paths = [f.resolve() for f in (repo_path / ".sccs" / "branches").rglob("*") if f.is_file() and f.stem == "history"]
-    byte_hash_paths = [f.resolve() for f in (repo_path / ".sccs" / "branches").rglob("*") if f.is_file() and f.stem == "commit_file_hash"]
+    history_paths = [
+        f.resolve() for f in (
+            repo_path / ".sccs" / "branches"
+        ).rglob("*") if f.is_file() and f.stem == "history"
+    ]
+    byte_hash_paths = [
+        f.resolve() for f in (
+            repo_path / ".sccs" / "branches"
+        ).rglob("*") if f.is_file() and f.stem == "commit_file_hash"
+    ]
 
     files_to_upload = (
         objects_paths
@@ -301,7 +316,11 @@ async def pull(repo_name: str, data: dict) -> StreamingResponse:
         for file_path in files_to_upload:
             zf.write(filename=file_path, arcname=file_path.relative_to(repo_path))
     buffer.seek(0)
-    return StreamingResponse(buffer, media_type="application/zip", headers={"Content-Disposition": f"attachment; filename={repo_name}.zip"})
+    return StreamingResponse(
+        buffer,
+        media_type="application/zip",
+        headers={"Content-Disposition": f"attachment; filename={repo_name}.zip"}
+    )
 
 
 app.mount("/repos", StaticFiles(directory="API/repos"), name="repos")

--- a/API/main.py
+++ b/API/main.py
@@ -243,5 +243,63 @@ async def push_upload(repo_name: str, file: UploadFile = File(...)) -> dict:
     return {"message": "changes pushed successfully"}
 
 
+@app.post("/repos/{repo_name}/pull")
+async def pull(repo_name: str, data: dict) -> StreamingResponse:
+    """
+    Send a zip archive of commit objects and metadata files that the local repository 
+    (caller) is missing by accepting a list of commit objects that the local doesn't 
+    have.
+    """
+
+    repo_name = resolve_path(Path(repo_name))
+    ensure_repository_exists(repo_name)
+    
+    repo_path = (Path("API/repos").resolve() / repo_name).resolve()
+
+    if (
+        not isinstance(data, dict) or
+        "objects" not in data or
+        not isinstance(data["objects"], list)
+    ):
+        raise HTTPException(status_code=400, detail="Invalid JSON data")
+
+    local_objects = data["objects"]
+
+    remote_objects = list(set(f.stem for f in (repo_path / ".sccs" / "objects").rglob("*") if f.is_file()))
+
+    obj_to_upload = list(set(remote_objects) - set(local_objects))
+
+
+
+    document_path = [repo_path / f"{repo_path.name}.docx"]
+    current_branch_path = [repo_path / ".sccs" / "current_branch" / "current_branch.json"]
+    commit_msgs_path = [repo_path / ".sccs" / "commit_messages" / "commit_messages.json"]
+
+    objects_paths = [
+        f.resolve()
+        for f in (repo_path / ".sccs" / "objects").rglob("*")
+        if f.is_file() and f.stem in obj_to_upload
+    ]
+
+    history_paths = [f.resolve() for f in (repo_path / ".sccs" / "branches").rglob("*") if f.is_file() and f.stem == "history"]
+    byte_hash_paths = [f.resolve() for f in (repo_path / ".sccs" / "branches").rglob("*") if f.is_file() and f.stem == "commit_file_hash"]
+
+    files_to_upload = (
+        objects_paths
+        + history_paths
+        + byte_hash_paths
+        + document_path
+        + current_branch_path
+        + commit_msgs_path
+    )
+        
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        for file_path in files_to_upload:
+            zf.write(filename=file_path, arcname=file_path.relative_to(repo_path))
+    buffer.seek(0)
+    return StreamingResponse(buffer, media_type="application/zip", headers={"Content-Disposition": f"attachment; filename={repo_name}.zip"})
+
+
 app.mount("/repos", StaticFiles(directory="API/repos"), name="repos")
 """Mount all repositories as static files on the /repos endpoint."""

--- a/API/main.py
+++ b/API/main.py
@@ -306,12 +306,14 @@ async def pull(repo_name: str, data: dict) -> StreamingResponse:
     ]
 
     files_to_upload = (
+        f for f in
         objects_paths
         + history_paths
         + byte_hash_paths
         + document_path
         + current_branch_path
         + commit_msgs_path
+        if f.isfile()
     )
 
     buffer = io.BytesIO()

--- a/API/main.py
+++ b/API/main.py
@@ -269,6 +269,9 @@ async def pull(repo_name: str, data: dict) -> StreamingResponse:
 
     obj_to_upload = list(set(remote_objects) - set(local_objects))
 
+    if list(set(local_objects) - set(remote_objects)):
+        raise HTTPException(status_code=400, detail="Local repository has objects that the remote does not have. Run 'sccs push' to upload these objects before pulling.")
+
 
 
     document_path = [repo_path / f"{repo_path.name}.docx"]

--- a/commands/clone.py
+++ b/commands/clone.py
@@ -89,8 +89,6 @@ def main() -> None:
     print(f"Repository cloned successfully to ./{repo_name}")
 
 
-
-
 if __name__ == "__main__":
     try:
         main()

--- a/commands/clone.py
+++ b/commands/clone.py
@@ -85,12 +85,10 @@ def main() -> None:
     unzip_repo_file(buffer, repo_name)
 
     print(f"Status Code: {response.status_code}")
-    if 200 <= response.status_code < 300:
-        print(f"Repository cloned successfully to ./{repo_name}")
-    else:
-        raise exceptions.HTTPGetRequestError(
-            f"Failed to clone repository: {response.text}"
-        )
+    response.raise_for_status()
+    print(f"Repository cloned successfully to ./{repo_name}")
+
+
 
 
 if __name__ == "__main__":

--- a/commands/exceptions.py
+++ b/commands/exceptions.py
@@ -266,5 +266,5 @@ class MissingCommitObjectsError(SCCSException):
 
     default_message = (
         "The local repository is missing commit objects that are present in the remote "
-        "repository. Run 'sccs pull' to download these objects before pulling."
+        "repository. Run 'sccs pull' to download these objects"
     )

--- a/commands/exceptions.py
+++ b/commands/exceptions.py
@@ -266,5 +266,5 @@ class MissingCommitObjectsError(SCCSException):
 
     default_message = (
         "The local repository is missing commit objects that are present in the remote "
-        "repository."
+        "repository. Run 'sccs pull' to download these objects before pulling."
     )

--- a/commands/publish.py
+++ b/commands/publish.py
@@ -104,12 +104,8 @@ def main() -> None:
     response = post_repo(zip_cwd(), remote)
 
     print(f"Status Code: {response.status_code}")
-    if 200 <= response.status_code < 300:
-        print(f"Repository published successfully to {remote}/publish")
-    else:
-        raise exceptions.HTTPPostRequestError(
-            f"Failed to publish repository: {response.text}"
-        )
+    response.raise_for_status()
+    print(f"Repository published successfully to {remote}")
 
 
 if __name__ == "__main__":

--- a/commands/pull.py
+++ b/commands/pull.py
@@ -21,6 +21,7 @@ def get_repo_objects(cwd: None | Path = None) -> list:
     objects = list(set(f.stem for f in objects_dir.rglob("*") if f.is_file()))
     return objects
 
+
 def pull(remote: str, data: dict) -> requests.Response:
     """Make a POST request to 'remote'/pull, returning the response."""
 

--- a/commands/pull.py
+++ b/commands/pull.py
@@ -21,15 +21,15 @@ def get_repo_objects(cwd: None | Path = None) -> list:
     objects = list(set(f.stem for f in objects_dir.rglob("*") if f.is_file()))
     return objects
 
-
 def pull(remote: str, data: dict) -> requests.Response:
-    """Make a GET request to 'remote'/pull, returning the response."""
+    """Make a POST request to 'remote'/pull, returning the response."""
 
     try:
         response = requests.post(f"{remote}/pull", json=data, timeout=60)
     except Exception as e:
-        raise exceptions.HTTPGetRequestError() from e
+        raise exceptions.HTTPPostRequestError() from e
 
+    return response
     return response
 
 

--- a/commands/pull.py
+++ b/commands/pull.py
@@ -33,9 +33,8 @@ def pull(remote: str, data: dict) -> requests.Response:
     return response
     return response
 
-def update_repo_files(
-    response: requests.Response, cwd: None | Path = None
-) -> None:
+
+def update_repo_files(response: requests.Response, cwd: None | Path = None) -> None:
     """
     Unzip the file in 'response' to 'destination'.
     """

--- a/commands/pull.py
+++ b/commands/pull.py
@@ -32,7 +32,9 @@ def pull(remote: str, data: dict) -> requests.Response:
     return response
 
 
-def update_repo_files(response: requests.Response, cwd: None | Path = None) -> io.BytesIO:
+def update_repo_files(
+        response: requests.Response, cwd: None | Path = None
+    ) -> io.BytesIO:
     """
     Unzip the file in 'response' to 'destination'.
     """

--- a/commands/pull.py
+++ b/commands/pull.py
@@ -49,10 +49,23 @@ def update_repo_files(response: requests.Response, cwd: None | Path = None) -> N
 def main():
     """Run functions for the <sccs pull> command."""
 
+    remote = utils.get_key_from_config("remote")
+    print(f"Pulling repository from {remote}...")
+
     response = pull(
-        utils.get_key_from_config("remote"), {"objects": get_repo_objects()}
-    )
-    print(response.status_code)
+        remote, {"objects": get_repo_objects()})
+    
+    print(f"Status Code: {response.status_code}")
+
+    if 200 <= response.status_code < 300:
+        update_repo_files(response)
+        print(f"Repository pulled successfully from {remote}")
+    else:
+        raise exceptions.HTTPGetRequestError(
+            f"Failed to pull repository: {response.text}"
+        )
+    
+    update_repo_files(response)
 
 
 if __name__ == "__main__":

--- a/commands/pull.py
+++ b/commands/pull.py
@@ -52,9 +52,8 @@ def main():
     remote = utils.get_key_from_config("remote")
     print(f"Pulling repository from {remote}...")
 
-    response = pull(
-        remote, {"objects": get_repo_objects()})
-    
+    response = pull(remote, {"objects": get_repo_objects()})
+
     print(f"Status Code: {response.status_code}")
 
     if 200 <= response.status_code < 300:
@@ -64,7 +63,7 @@ def main():
         raise exceptions.HTTPGetRequestError(
             f"Failed to pull repository: {response.text}"
         )
-    
+
     update_repo_files(response)
 
 

--- a/commands/pull.py
+++ b/commands/pull.py
@@ -1,0 +1,50 @@
+import sys
+import zipfile
+from pathlib import Path
+import requests
+import utils
+import exceptions
+
+
+def get_repo_objects(cwd: None | Path = None) -> list:
+    """
+    Return of list of every commit hash by iterating through the objects folder's file
+    stems, and removing duplicates with a set.
+    """
+
+    if cwd is None:
+        cwd = utils.working_directory_path
+    objects_dir = cwd / ".sccs" / "objects"
+    objects = list(set(f.stem for f in objects_dir.rglob("*") if f.is_file()))
+    return objects
+
+
+def pull(remote: str, data: dict) -> requests.Response:
+    """Make a GET request to 'remote'/pull, returning the response."""
+
+    try:
+        response = requests.post(f"{remote}/pull", json=data, timeout=60)
+    except Exception as e:
+        raise exceptions.HTTPGetRequestError() from e
+
+    return response
+
+
+def main():
+    """Run functions for the <sccs pull> command."""
+
+    response = pull(
+        utils.get_key_from_config("remote"), {"objects": get_repo_objects()})
+    print(response.status_code)
+
+if __name__ == "__main__":
+    try:
+        main()
+
+    except exceptions.SCCSException as e:
+        print(f"An error occurred:\n{e}\n")
+        sys.exit(1)
+
+    except Exception as e:
+        print(f"An unexpected error occurred:\n\n{type(e).__name__}: {e}\n")
+        sys.exit(2)

--- a/commands/pull.py
+++ b/commands/pull.py
@@ -58,7 +58,7 @@ def main():
 
     response.raise_for_status()
     print(f"Repository pulled successfully from {remote}")
-    
+
     update_repo_files(response)
 
 

--- a/commands/pull.py
+++ b/commands/pull.py
@@ -33,10 +33,9 @@ def pull(remote: str, data: dict) -> requests.Response:
     return response
     return response
 
-
 def update_repo_files(
     response: requests.Response, cwd: None | Path = None
-) -> io.BytesIO:
+) -> None:
     """
     Unzip the file in 'response' to 'destination'.
     """
@@ -44,14 +43,7 @@ def update_repo_files(
     if cwd is None:
         cwd = utils.working_directory_path
 
-    buffer = io.BytesIO()
-
-    for chunk in response.iter_content(chunk_size=8192):
-        buffer.write(chunk)
-
-    buffer.seek(0)
-
-    with zipfile.ZipFile(buffer, "r") as zf:
+    with zipfile.ZipFile(io.BytesIO(response.content), "r") as zf:
         zf.extractall(cwd)
 
 

--- a/commands/pull.py
+++ b/commands/pull.py
@@ -1,10 +1,11 @@
+import io
 import sys
 import zipfile
 from pathlib import Path
+
+import exceptions
 import requests
 import utils
-import exceptions
-import io
 
 
 def get_repo_objects(cwd: None | Path = None) -> list:
@@ -33,15 +34,14 @@ def pull(remote: str, data: dict) -> requests.Response:
 
 
 def update_repo_files(
-        response: requests.Response, cwd: None | Path = None
-    ) -> io.BytesIO:
+    response: requests.Response, cwd: None | Path = None
+) -> io.BytesIO:
     """
     Unzip the file in 'response' to 'destination'.
     """
 
     if cwd is None:
         cwd = utils.working_directory_path
-
 
     buffer = io.BytesIO()
 
@@ -58,8 +58,10 @@ def main():
     """Run functions for the <sccs pull> command."""
 
     response = pull(
-        utils.get_key_from_config("remote"), {"objects": get_repo_objects()})
+        utils.get_key_from_config("remote"), {"objects": get_repo_objects()}
+    )
     print(response.status_code)
+
 
 if __name__ == "__main__":
     try:

--- a/commands/pull.py
+++ b/commands/pull.py
@@ -56,14 +56,9 @@ def main():
 
     print(f"Status Code: {response.status_code}")
 
-    if 200 <= response.status_code < 300:
-        update_repo_files(response)
-        print(f"Repository pulled successfully from {remote}")
-    else:
-        raise exceptions.HTTPGetRequestError(
-            f"Failed to pull repository: {response.text}"
-        )
-
+    response.raise_for_status()
+    print(f"Repository pulled successfully from {remote}")
+    
     update_repo_files(response)
 
 

--- a/commands/pull.py
+++ b/commands/pull.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import requests
 import utils
 import exceptions
+import io
 
 
 def get_repo_objects(cwd: None | Path = None) -> list:
@@ -14,6 +15,7 @@ def get_repo_objects(cwd: None | Path = None) -> list:
 
     if cwd is None:
         cwd = utils.working_directory_path
+
     objects_dir = cwd / ".sccs" / "objects"
     objects = list(set(f.stem for f in objects_dir.rglob("*") if f.is_file()))
     return objects
@@ -28,6 +30,26 @@ def pull(remote: str, data: dict) -> requests.Response:
         raise exceptions.HTTPGetRequestError() from e
 
     return response
+
+
+def update_repo_files(response: requests.Response, cwd: None | Path = None) -> io.BytesIO:
+    """
+    Unzip the file in 'response' to 'destination'.
+    """
+
+    if cwd is None:
+        cwd = utils.working_directory_path
+
+
+    buffer = io.BytesIO()
+
+    for chunk in response.iter_content(chunk_size=8192):
+        buffer.write(chunk)
+
+    buffer.seek(0)
+
+    with zipfile.ZipFile(buffer, "r") as zf:
+        zf.extractall(cwd)
 
 
 def main():

--- a/commands/push.py
+++ b/commands/push.py
@@ -222,10 +222,7 @@ def main() -> None:
 
     GET_response = push_GET(remote)
 
-    if not 200 <= GET_response.status_code < 300:
-        raise exceptions.HTTPGetRequestError(
-            f"Failed to push to repository: {GET_response.text}, status code: {GET_response.status_code}"
-        )
+    GET_response.raise_for_status()
 
     remote_objects = GET_response.json().get("objects", [])
 
@@ -237,12 +234,8 @@ def main() -> None:
 
     print(f"Status code: {POST_response.status_code}")
 
-    if 200 <= POST_response.status_code < 300:
-        print(f"Changes pushed successfully to {remote}/push\n")
-    else:
-        raise exceptions.HTTPPostRequestError(
-            f"Failed to push to repository: {POST_response.text}, status code: {POST_response.status_code}"
-        )
+    POST_response.raise_for_status()
+    print(f"Changes pushed successfully to {remote}/push\n")
 
     clear_updated_branches()
 

--- a/commands/sccs
+++ b/commands/sccs
@@ -22,7 +22,8 @@ COMMANDS = [
     "config",
     "revert",
     "reset",
-    "push"
+    "push",
+    "pull",
 ]
 
 

--- a/commands/sccs.bat
+++ b/commands/sccs.bat
@@ -93,6 +93,12 @@ if "%command%"=="push" (
     exit /b !errorlevel!
 )
 
+if "%command%"=="pull" (
+    set "script_directory=%~dp0"
+    python "%script_directory%pull.py" %*
+    exit /b !errorlevel!
+)
+
 echo Unknown command: %command%
 echo Invalid command. Please use "init", "commit", "open", "log", "status", "diff", "help", "branch", "switch", "publish", "clone", "config", "revert", "reset", or "push", along with required arguments
 echo For help, use the 'sccs help' command


### PR DESCRIPTION
# Closes #127 

This PR focuses on creating a new command for the SCCS CLI, `sccs pull` by implementing a endpoint `"/repos/{repo_name}/pull"` for the HTTP API, which returns is used to update the local version of the repository.

## SCCS, SCCS.bat

- Add tunnel for `pull.py`
- Update fallback message

## Exceptions.py

- Update default message for the `MissingCommitObjectsError` exception.

## Main.py

- Create new endpoint `"/repos/{repo_name}/pull"` which:
1. Takes a list of repository objects
2. Returns a zip archive of objects that local is missing and metadata files.

## Pull.py

- Makes a POST requests to `"/repos/{repo_name}/pull"` with a list of commit objects that the local repository has.
- Uses the returned zip archive to update the objects directory, metadata files, and the repo document

## Type of Change

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
