### PR TITLE
feat: only print first 10 chars of hash

### DIFF
--- a/commands/commit.py
+++ b/commands/commit.py
@@ -27,7 +27,7 @@ def get_commit_message() -> str:
 def print_commit_confirmation_message(sha_hash: str) -> None:
     """Print a confirmation message for the commit using 'sha_hash'."""
 
-    print(f"Commit {sha_hash} created successfully.")
+    print(f"Commit {sha_hash[:10]} created successfully.")
 
 
 def main() -> None:

--- a/commands/open.py
+++ b/commands/open.py
@@ -62,7 +62,7 @@ def print_rewrite_confirmation_message(
         docx_path = utils.current_file_docx_path
     print(
         f"File '{docx_path.name}' has been updated with the contents of "
-        f"'{commit_path.name}'."
+        f"'{commit_path.name[:10]}'."
     )
 
 

--- a/commands/revert.py
+++ b/commands/revert.py
@@ -30,8 +30,8 @@ def print_revert_confirmation_message(commit: Path, new_commit_hash: str) -> Non
     """Print a confirmation message for the revert."""
 
     print(
-        f"Document successfully reverted to commit '{commit.stem}' on commit "
-        f"'{new_commit_hash}'."
+        f"Document successfully reverted to commit '{commit.stem[:10]}' on commit "
+        f"'{new_commit_hash[:10]}'."
     )
 
 


### PR DESCRIPTION
# Closes #155 

This PR changes the codebase so that only the first ten characters of a commit hash are printed to the user.

## Type of Change

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
