### PR TITLE
fix: add utils.check_sccs_layout to files that don't have it 

### DIFF
--- a/commands/clone.py
+++ b/commands/clone.py
@@ -7,6 +7,7 @@ import zipfile
 
 import exceptions
 import requests
+import utils
 
 
 def get_entered_url() -> str | None:
@@ -74,6 +75,8 @@ def unzip_repo_file(buffer: io.BytesIO, destination: str) -> None:
 
 def main() -> None:
     """Run functions for the <sccs clone> command."""
+    utils.check_sccs_layout()
+
     response = request_repo()
 
     repo_name = resolve_entered_url().split("/")[-2]

--- a/commands/config.py
+++ b/commands/config.py
@@ -82,6 +82,8 @@ def resolve_entered_remote(remote: str) -> str:
 
 def main() -> None:
     """Run functions for the <sccs config> command."""
+    utils.check_sccs_layout()
+
     key = get_entered_config_key()
     value = get_entered_config_value()
 

--- a/commands/help.py
+++ b/commands/help.py
@@ -4,6 +4,7 @@
 import sys
 
 import exceptions
+import utils
 
 MESSAGES_TO_PRINT = [
     "SCCS Help",
@@ -37,6 +38,7 @@ def print_help(messages: list[str]) -> None:
 
 def main() -> None:
     """Run functions for the <sccs help> command."""
+    utils.check_sccs_layout()
 
     print_help(MESSAGES_TO_PRINT)
 

--- a/commands/log.py
+++ b/commands/log.py
@@ -58,7 +58,6 @@ def print_log() -> None:
 
 def main() -> None:
     """Run functions for the <sccs log> command."""
-
     utils.check_sccs_layout()
 
     print_log()

--- a/commands/open.py
+++ b/commands/open.py
@@ -68,7 +68,6 @@ def print_rewrite_confirmation_message(
 
 def main() -> None:
     """Run functions for the <sccs open> command."""
-
     utils.check_sccs_layout()
 
     commit_path = utils.validate_commit(

--- a/commands/publish.py
+++ b/commands/publish.py
@@ -97,6 +97,8 @@ def post_repo(buffer: io.BytesIO, remote: str) -> requests.Response:
 
 def main() -> None:
     """Run functions for the <sccs publish> command."""
+    utils.check_sccs_layout()
+
     reset_current_branch()
 
     remote = utils.get_key_from_config("remote")

--- a/commands/pull.py
+++ b/commands/pull.py
@@ -47,6 +47,7 @@ def update_repo_files(response: requests.Response, cwd: None | Path = None) -> N
 
 def main():
     """Run functions for the <sccs pull> command."""
+    utils.check_sccs_layout()
 
     remote = utils.get_key_from_config("remote")
     print(f"Pulling repository from {remote}...\n")

--- a/commands/push.py
+++ b/commands/push.py
@@ -215,6 +215,7 @@ def clear_updated_branches(cwd: None | Path = None) -> None:
 
 def main() -> None:
     """Run functions for the <sccs push> command."""
+    utils.check_sccs_layout()
 
     remote = utils.get_key_from_config("remote").rstrip("/")
 

--- a/commands/reset.py
+++ b/commands/reset.py
@@ -49,6 +49,7 @@ def print_success_message() -> None:
 def main() -> None:
     """Main function to handle the <reset> command."""
     utils.check_sccs_layout()
+    
     reset()
     print_success_message()
 

--- a/commands/reset.py
+++ b/commands/reset.py
@@ -49,7 +49,7 @@ def print_success_message() -> None:
 def main() -> None:
     """Main function to handle the <reset> command."""
     utils.check_sccs_layout()
-    
+
     reset()
     print_success_message()
 

--- a/commands/switch.py
+++ b/commands/switch.py
@@ -137,7 +137,6 @@ def print_confirmation(branch_to_switch: str) -> None:
 
 def main() -> None:
     """Run functions for the <sccs switch> command."""
-
     utils.check_sccs_layout()
 
     branches = utils.get_branch_data(key="branches")


### PR DESCRIPTION
# Closes #157 

This PR adds `utils.check_sccs_layout` to all files which lack it and keep blank lines consistent, placing the call on the first line after the docstring and using 1 blank line after it.

## Type of Change

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
